### PR TITLE
feat(core): add find_first_not_of methods to FixString class

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -199,7 +199,10 @@
         {
             "name": "macos-ninja-debug",
             "configurePreset": "macos-ninja-debug",
-            "inherits": "default-debug"
+            "inherits": "default-debug",
+            "execution": {
+                "stopOnFailure": true
+            }
         },
         {
             "name": "linux-ninja-debug",

--- a/include/core/fix_string.hpp
+++ b/include/core/fix_string.hpp
@@ -1603,7 +1603,7 @@ private:
 
     \return The position of the first occurrence of any character from \a data, or \ref npos if not found.
 
-    \pre The \a position must be less than or equal to the string size.
+    \pre The \a position must be less than the string size.
     \pre The \a data must not be null.
   */
   constexpr inline std::size_t _find_first_of_raw(std::size_t position, const char * data,
@@ -1621,7 +1621,7 @@ private:
 
     \return The position of the first occurrence of any character not from \a data, or \ref npos if not found.
 
-    \pre The \a position must be less than or equal to the string size.
+    \pre The \a position must be less than the string size.
     \pre The \a data must not be null.
   */
   constexpr inline std::size_t _find_first_not_of_raw(std::size_t position, const char * data,

--- a/include/core/fix_string.hpp
+++ b/include/core/fix_string.hpp
@@ -941,7 +941,7 @@ public:
 
     \return The position of the first occurrence of other \a string, or \ref npos if not found.
 
-    \pre The \a position must be less than or equal to the string size.
+    \pre The \a position must be less than the string size.
 
     \note The search is case-sensitive.
   */
@@ -960,7 +960,7 @@ public:
 
     \return The position of the first occurrence of a StringLike object, or \ref npos if not found.
 
-    \pre The \a position must be less than or equal to the string size.
+    \pre The \a position must be less than the string size.
 
     \note The search is case-sensitive.
   */
@@ -978,7 +978,7 @@ public:
 
     \return The position of the first occurrence of the C \a string, or \ref npos if not found.
 
-    \pre The \a position must be less than or equal to the string size.
+    \pre The \a position must be less than the string size.
     \pre The \a string must not be null.
 
     \note The search is case-sensitive.
@@ -996,7 +996,7 @@ public:
 
     \return The position of the first occurrence of the \a character, or \ref npos if not found.
 
-    \pre The \a position must be less than or equal to the string size.
+    \pre The \a position must be less than the string size.
 
     \note The search is case-sensitive.
   */
@@ -1095,7 +1095,7 @@ public:
 
     \return The position of the first occurrence of any character from \a string, or \ref npos if not found.
 
-    \pre The \a position must be less than or equal to the string size.
+    \pre The \a position must be less than the string size.
 
     \note The search is case-sensitive.
     \note If \a string is empty, this method returns \ref npos.
@@ -1116,7 +1116,7 @@ public:
 
     \return The position of the first occurrence of any character from a StringLike object, or \ref npos if not found.
 
-    \pre The \a position must be less than or equal to the string size.
+    \pre The \a position must be less than the string size.
 
     \note The search is case-sensitive.
     \note If a StringLike object is empty, this method returns \ref npos.
@@ -1135,7 +1135,7 @@ public:
 
     \return The position of the first occurrence of any character from the C \a string, or \ref npos if not found.
 
-    \pre The \a position must be less than or equal to the string size.
+    \pre The \a position must be less than the string size.
     \pre The \a string must not be null.
 
     \note The search is case-sensitive.
@@ -1154,12 +1154,91 @@ public:
 
     \return The position of the first occurrence of the \a character, or \ref npos if not found.
 
-    \pre The \a position must be less than or equal to the string size.
+    \pre The \a position must be less than the string size.
 
     \note The search is case-sensitive.
     \note This method is equivalent to find(character, position).
   */
   constexpr inline std::size_t find_first_of(char character, std::size_t position = 0) const noexcept;
+
+  /*!
+    \brief Finds the first occurrence of any character not from the specified \a string.
+
+    This method searches for the first occurrence of any character that is not present in the specified \a string within
+    this string, starting from the given \a position.
+
+    \param string   The string containing characters to exclude from search.
+    \param position The position to start searching from (default: 0).
+
+    \return The position of the first occurrence of any character not from \a string, or \ref npos if not found.
+
+    \pre The \a position must be less than the string size.
+
+    \note The search is case-sensitive.
+    \note If \a string is empty, this method returns \a position if it's within bounds, otherwise returns \ref npos.
+  */
+  constexpr inline std::size_t find_first_not_of(const FixString<allocatedSize> & string,
+                                                 std::size_t position = 0) const noexcept;
+
+  /*!
+    \brief Finds the first occurrence of any character not from a StringLike object.
+
+    This method searches for the first occurrence of any character that is not present in a StringLike object within
+    this string, starting from the given \a position.
+
+    \tparam stringType The type of the source string. Must satisfy the StringLike concept.
+
+    \param string   The StringLike object containing characters to exclude from search.
+    \param position The position to start searching from (default: 0).
+
+    \return The position of the first occurrence of any character not from a StringLike object, or \ref npos if not
+            found.
+
+    \pre The \a position must be less than the string size.
+
+    \note The search is case-sensitive.
+    \note If a StringLike object is empty, this method returns \a position if it's within bounds, otherwise returns \ref
+          npos.
+  */
+  template <StringLike stringType>
+  constexpr inline std::size_t find_first_not_of(const stringType & string, std::size_t position = 0) const noexcept;
+
+  /*!
+    \brief Finds the first occurrence of any character not from the C \a string.
+
+    This method searches for the first occurrence of any character that is not present in the C \a string within this
+    string, starting from the given \a position.
+
+    \param string   The C string containing characters to exclude from search.
+    \param position The position to start searching from (default: 0).
+
+    \return The position of the first occurrence of any character not from the C \a string, or \ref npos if not found.
+
+    \pre The \a position must be less than the string size.
+    \pre The \a string must not be null.
+
+    \note The search is case-sensitive.
+    \note If the C \a string is empty, this method returns \a position if it's within bounds, otherwise returns \ref
+          npos.
+  */
+  constexpr inline std::size_t find_first_not_of(const char * string, std::size_t position = 0) const noexcept;
+
+  /*!
+    \brief Finds the first occurrence of any character not equal to the specified \a character.
+
+    This method searches for the first occurrence of any character that is not equal to the specified \a character
+    within this string, starting from the given \a position.
+
+    \param character The character to exclude from search.
+    \param position  The position to start searching from (default: 0).
+
+    \return The position of the first occurrence of any character not equal to \a character, or \ref npos if not found.
+
+    \pre The \a position must be less than the string size.
+
+    \note The search is case-sensitive.
+  */
+  constexpr inline std::size_t find_first_not_of(char character, std::size_t position = 0) const noexcept;
 
   /*!
     \brief Compares this string with another \a string lexicographically.
@@ -1529,6 +1608,24 @@ private:
   */
   constexpr inline std::size_t _find_first_of_raw(std::size_t position, const char * data,
                                                   std::size_t dataSize) const noexcept;
+
+  /*!
+    \brief Helper method for finding the first occurrence of any character not from \a data.
+
+    This private method performs the common search logic used by all find_first_not_of methods. It searches for the
+    first occurrence of any character that is not present in the specified \a data starting from the given \a position.
+
+    \param position The position to start searching from.
+    \param data     The data containing characters to exclude from search.
+    \param dataSize The size of the data containing characters to exclude from search.
+
+    \return The position of the first occurrence of any character not from \a data, or \ref npos if not found.
+
+    \pre The \a position must be less than or equal to the string size.
+    \pre The \a data must not be null.
+  */
+  constexpr inline std::size_t _find_first_not_of_raw(std::size_t position, const char * data,
+                                                      std::size_t dataSize) const noexcept;
 
   char _data[allocatedSize];
   std::size_t _size;

--- a/include/core/fix_string.inl
+++ b/include/core/fix_string.inl
@@ -636,6 +636,33 @@ constexpr inline std::size_t FixString<allocatedSize>::find_first_of(char charac
 }
 
 template <std::size_t allocatedSize>
+constexpr inline std::size_t FixString<allocatedSize>::find_first_not_of(const FixString<allocatedSize> & string,
+                                                                         std::size_t position) const noexcept {
+  return _find_first_not_of_raw(position, string._data, string._size);
+}
+
+template <std::size_t allocatedSize>
+template <StringLike stringType>
+constexpr inline std::size_t FixString<allocatedSize>::find_first_not_of(const stringType & string,
+                                                                         std::size_t position) const noexcept {
+  return _find_first_not_of_raw(position, string.c_str(), string.size());
+}
+
+template <std::size_t allocatedSize>
+constexpr inline std::size_t FixString<allocatedSize>::find_first_not_of(const char * string,
+                                                                         std::size_t position) const noexcept {
+  assert_message(string != nullptr, "String pointer must not be null");
+
+  return _find_first_not_of_raw(position, string, std::strlen(string));
+}
+
+template <std::size_t allocatedSize>
+constexpr inline std::size_t FixString<allocatedSize>::find_first_not_of(char character,
+                                                                         std::size_t position) const noexcept {
+  return _find_first_not_of_raw(position, &character, 1);
+}
+
+template <std::size_t allocatedSize>
 constexpr inline int FixString<allocatedSize>::compare(const FixString<allocatedSize> & string) const noexcept {
   return std::strcmp(_data, string._data);
 }
@@ -855,6 +882,40 @@ constexpr inline std::size_t FixString<allocatedSize>::_find_first_of_raw(std::s
   const auto occurrence = dataSize == 1 ? std::strchr(_data + position, data[0]) : std::strpbrk(_data + position, data);
 
   return occurrence != nullptr ? occurrence - _data : npos;
+}
+
+template <std::size_t allocatedSize>
+constexpr inline std::size_t FixString<allocatedSize>::_find_first_not_of_raw(std::size_t position, const char * data,
+                                                                              std::size_t dataSize) const noexcept {
+  if (position >= _size)
+    return npos;
+
+  if (dataSize == 0)
+    return position;
+
+  if (dataSize == 1) {
+    const auto exclude = data[0];
+    for (auto i = position; i < _size; ++i) {
+      if (_data[i] != exclude)
+        return i;
+    }
+
+    return npos;
+  }
+
+  std::array<bool, 256> lookup{};
+  lookup.fill(true);
+
+  for (std::size_t i = 0; i < dataSize; ++i) {
+    lookup[static_cast<unsigned char>(data[i])] = false;
+  }
+
+  for (auto i = position; i < _size; ++i) {
+    if (lookup[static_cast<unsigned char>(_data[i])])
+      return i;
+  }
+
+  return npos;
 }
 
 } // namespace toygine

--- a/include/core/fix_string.inl
+++ b/include/core/fix_string.inl
@@ -903,15 +903,14 @@ constexpr inline std::size_t FixString<allocatedSize>::_find_first_not_of_raw(st
     return npos;
   }
 
-  std::array<bool, 256> lookup{};
-  lookup.fill(true);
+  std::array<bool, 256> excludedChars{};
 
   for (std::size_t i = 0; i < dataSize; ++i) {
-    lookup[static_cast<unsigned char>(data[i])] = false;
+    excludedChars[static_cast<unsigned char>(data[i])] = true;
   }
 
   for (auto i = position; i < _size; ++i) {
-    if (lookup[static_cast<unsigned char>(_data[i])])
+    if (!excludedChars[static_cast<unsigned char>(_data[i])])
       return i;
   }
 

--- a/src/core/core.hpp.in
+++ b/src/core/core.hpp.in
@@ -26,6 +26,7 @@
 #define INCLUDE_CORE_HPP_
 
 #include <algorithm>
+#include <array>
 #include <concepts>
 #include <cstddef>
 #include <cstdint>

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -17,7 +17,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 //
-#include <array>
 #include <bit>
 #include <cmath>
 

--- a/test/core/core_utils_test.cpp
+++ b/test/core/core_utils_test.cpp
@@ -18,8 +18,6 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-#include <array>
-
 #include <catch2/catch_test_macros.hpp>
 
 #include "core.hpp"

--- a/test/core/fix_string_test.cpp
+++ b/test/core/fix_string_test.cpp
@@ -18,8 +18,6 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-#include <array>
-
 #include <catch2/catch_test_macros.hpp>
 
 #include "core.hpp"
@@ -1598,6 +1596,191 @@ TEST_CASE("FixString find_first_of", "[core][fixstring]") {
     CHECK(testString.find_first_of("0123456789") == FixString<32>::npos);
     CHECK(testString.find_first_of("!@#$%^&*()") == FixString<32>::npos);
     CHECK(testString.find_first_of("[]{}|\\:;\"'<>?/") == FixString<32>::npos);
+  }
+}
+
+TEST_CASE("FixString find_first_not_of", "[core][fixstring]") {
+  SECTION("Find first not of FixString characters") {
+    FixString<32> testString("Hello World");
+
+    CHECK(testString.find_first_not_of(FixString<16>("H")) == 1); // 'e' at position 1
+    CHECK(testString.find_first_not_of(FixString<16>("Hel")) == 4); // 'o' at position 4
+    CHECK(testString.find_first_not_of(FixString<16>("Helo Wrd")) == FixString<32>::npos);
+  }
+
+  SECTION("Find first not of StringLike characters") {
+    FixString<32> testString("Hello World");
+
+    CHECK(testString.find_first_not_of(std::string("H")) == 1); // 'e' at position 1
+    CHECK(testString.find_first_not_of(std::string("Hel")) == 4); // 'o' at position 4
+    CHECK(testString.find_first_not_of(std::string("Helo Wrd")) == FixString<32>::npos);
+  }
+
+  SECTION("Find first not of C string characters") {
+    FixString<32> testString("Hello World");
+
+    CHECK(testString.find_first_not_of("H") == 1); // 'e' at position 1
+    CHECK(testString.find_first_not_of("Hel") == 4); // 'o' at position 4
+    CHECK(testString.find_first_not_of("Helo Wrd") == FixString<32>::npos);
+  }
+
+  SECTION("Find first not of single character") {
+    FixString<32> testString("aaaaab");
+
+    CHECK(testString.find_first_not_of('a') == 5); // 'b' at position 5
+    CHECK(testString.find_first_not_of('b') == 0); // 'a' at position 0
+    CHECK(testString.find_first_not_of('x') == 0); // 'a' at position 0
+  }
+
+  SECTION("Find first not of with position parameter") {
+    FixString<32> testString("Hello World Hello");
+
+    CHECK(testString.find_first_not_of("Hel", 0) == 4); // 'o' at position 4
+    CHECK(testString.find_first_not_of("Hel", 4) == 4); // 'o' at position 4
+    CHECK(testString.find_first_not_of("Hel", 5) == 5); // ' ' at position 5
+    CHECK(testString.find_first_not_of("Hel", 6) == 6); // 'W' at position 6
+    CHECK(testString.find_first_not_of("Hel", 7) == 7); // 'o' at position 7
+  }
+
+  SECTION("Find first not of empty character set") {
+    FixString<32> testString("Hello World");
+
+    CHECK(testString.find_first_not_of(FixString<16>("")) == 0); // 'H' at position 0
+    CHECK(testString.find_first_not_of(std::string("")) == 0); // 'H' at position 0
+    CHECK(testString.find_first_not_of("") == 0); // 'H' at position 0
+    CHECK(testString.find_first_not_of("", 5) == 5); // ' ' at position 5
+  }
+
+  SECTION("Find first not of in empty string") {
+    FixString<32> testString("");
+
+    CHECK(testString.find_first_not_of(FixString<16>("aeiou")) == FixString<32>::npos);
+    CHECK(testString.find_first_not_of(std::string("aeiou")) == FixString<32>::npos);
+    CHECK(testString.find_first_not_of("aeiou") == FixString<32>::npos);
+    CHECK(testString.find_first_not_of('a') == FixString<32>::npos);
+  }
+
+  SECTION("Find first not of with position beyond string size") {
+    FixString<32> testString("Hello");
+
+    CHECK(testString.find_first_not_of("aeiou", 10) == FixString<32>::npos);
+    CHECK(testString.find_first_not_of('a', 10) == FixString<32>::npos);
+  }
+
+  SECTION("Find first not of with repeated characters") {
+    FixString<32> testString("aaaaa");
+
+    CHECK(testString.find_first_not_of("a") == FixString<32>::npos);
+    CHECK(testString.find_first_not_of("ab") == FixString<32>::npos);
+    CHECK(testString.find_first_not_of("b") == 0); // 'a' at position 0
+  }
+
+  SECTION("Find first not of with multiple character sets") {
+    FixString<32> testString("Hello World");
+
+    CHECK(testString.find_first_not_of("Hl") == 1); // 'e' at position 1
+    CHECK(testString.find_first_not_of("Hel") == 4); // 'o' at position 4
+    CHECK(testString.find_first_not_of("Helo") == 5); // ' ' at position 5
+    CHECK(testString.find_first_not_of("Helo ") == 6); // 'W' at position 6
+  }
+
+  SECTION("Find first not of case sensitivity") {
+    FixString<32> testString("Hello World");
+
+    CHECK(testString.find_first_not_of("h") == 0); // 'H' at position 0
+    CHECK(testString.find_first_not_of("H") == 1); // 'e' at position 1
+    CHECK(testString.find_first_not_of("w") == 0); // 'H' at position 0
+    CHECK(testString.find_first_not_of("W") == 0); // 'H' at position 0
+  }
+
+  SECTION("Find first not of with special characters") {
+    FixString<32> testString("Hello, World!");
+
+    CHECK(testString.find_first_not_of("Helo, Wrd!") == FixString<32>::npos);
+    CHECK(testString.find_first_not_of("Helo, Wrd") == 12); // '!' at position 12
+    CHECK(testString.find_first_not_of("Helo, Wrd!") == FixString<32>::npos);
+  }
+
+  SECTION("Find first not of with numbers") {
+    FixString<32> testString("Hello123World");
+
+    CHECK(testString.find_first_not_of("0123456789") == 0); // 'H' at position 0
+    CHECK(testString.find_first_not_of("Helo123Wrd") == FixString<32>::npos);
+    CHECK(testString.find_first_not_of("Helo123Wr") == 12); // 'd' at position 12
+  }
+
+  SECTION("Find first not of with whitespace") {
+    FixString<32> testString("Hello World\t\n");
+
+    CHECK(testString.find_first_not_of(" \t\n") == 0); // 'H' at position 0
+    CHECK(testString.find_first_not_of("Helo Wrd\t\n") == FixString<32>::npos);
+    CHECK(testString.find_first_not_of("Helo Wrd") == 11); // '\t' at position 11
+  }
+
+  SECTION("Find first not of with different FixString capacities") {
+    FixString<32> testString("Hello World");
+
+    CHECK(testString.find_first_not_of(FixString<8>("H")) == 1);
+    CHECK(testString.find_first_not_of(FixString<16>("H")) == 1);
+    CHECK(testString.find_first_not_of(FixString<64>("H")) == 1);
+  }
+
+  SECTION("Find first not of with single character string") {
+    FixString<32> testString("A");
+
+    CHECK(testString.find_first_not_of("A") == FixString<32>::npos);
+    CHECK(testString.find_first_not_of('A') == FixString<32>::npos);
+    CHECK(testString.find_first_not_of("B") == 0); // 'A' at position 0
+    CHECK(testString.find_first_not_of('B') == 0); // 'A' at position 0
+  }
+
+  SECTION("Find first not of with position 0") {
+    FixString<32> testString("Hello World");
+
+    CHECK(testString.find_first_not_of("H", 0) == 1);
+    CHECK(testString.find_first_not_of("Hel", 0) == 4);
+    CHECK(testString.find_first_not_of("Helo Wrd", 0) == FixString<32>::npos);
+  }
+
+  SECTION("Find first not of with all characters excluded") {
+    FixString<32> testString("abcdefghijklmnopqrstuvwxyz");
+
+    CHECK(testString.find_first_not_of("abcdefghijklmnopqrstuvwxyz") == FixString<32>::npos);
+    CHECK(testString.find_first_not_of("abcdefghijklmnopqrstuvwxy") == 25); // 'z' at position 25
+    CHECK(testString.find_first_not_of("abcdefghijklmnopqrstuvwx") == 24); // 'y' at position 24
+  }
+
+  SECTION("Find first not of with no characters excluded") {
+    FixString<32> testString("Hello World");
+
+    CHECK(testString.find_first_not_of("xyz") == 0); // 'H' at position 0
+    CHECK(testString.find_first_not_of("0123456789") == 0); // 'H' at position 0
+    CHECK(testString.find_first_not_of("!@#$%^&*()") == 0); // 'H' at position 0
+  }
+
+  SECTION("Find first not of with mixed content") {
+    FixString<32> testString("Hello123World");
+
+    CHECK(testString.find_first_not_of("Helo123Wrd") == FixString<32>::npos);
+    CHECK(testString.find_first_not_of("Helo123Wr") == 12); // 'd' at position 12
+    CHECK(testString.find_first_not_of("Helo123Wd") == 10); // 'r' at position 10
+  }
+
+  SECTION("Find first not of with position in middle") {
+    FixString<32> testString("Hello World Hello");
+
+    CHECK(testString.find_first_not_of("Hel", 4) == 4); // 'o' at position 4
+    CHECK(testString.find_first_not_of("Hel", 5) == 5); // ' ' at position 5
+    CHECK(testString.find_first_not_of("Hel", 6) == 6); // 'W' at position 6
+    CHECK(testString.find_first_not_of("Hel", 7) == 7); // 'o' at position 7
+  }
+
+  SECTION("Find first not of with exact match") {
+    FixString<32> testString("Hello");
+
+    CHECK(testString.find_first_not_of("Hello") == FixString<32>::npos);
+    CHECK(testString.find_first_not_of("Hell") == 4); // 'o' at position 4
+    CHECK(testString.find_first_not_of("Hel") == 4); // 'o' at position 4
   }
 }
 

--- a/test/core/fix_string_test.cpp
+++ b/test/core/fix_string_test.cpp
@@ -1698,7 +1698,6 @@ TEST_CASE("FixString find_first_not_of", "[core][fixstring]") {
 
     CHECK(testString.find_first_not_of("Helo, Wrd!") == FixString<32>::npos);
     CHECK(testString.find_first_not_of("Helo, Wrd") == 12); // '!' at position 12
-    CHECK(testString.find_first_not_of("Helo, Wrd!") == FixString<32>::npos);
   }
 
   SECTION("Find first not of with numbers") {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `find_first_not_of` methods to FixString class

- Fix precondition documentation for search methods

- Remove unused array includes from source files

- Add comprehensive test coverage for new functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FixString Class"] --> B["find_first_not_of Methods"]
  B --> C["FixString Overload"]
  B --> D["StringLike Template"]
  B --> E["C String Overload"]
  B --> F["Character Overload"]
  G["Helper Method"] --> H["_find_first_not_of_raw"]
  I["Documentation"] --> J["Precondition Fixes"]
  K["Tests"] --> L["Comprehensive Coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fix_string.hpp</strong><dd><code>Add find_first_not_of methods and fix documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/core/fix_string.hpp

<ul><li>Add four <code>find_first_not_of</code> method declarations with comprehensive <br>documentation<br> <li> Fix precondition documentation from "less than or equal to" to "less <br>than" for all search methods<br> <li> Add private helper method <code>_find_first_not_of_raw</code> declaration</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/89/files#diff-2ef8f9f195db23c05d195ee56d0aaa0c714eeaf911132af27804a48fa895ce44">+105/-8</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fix_string.inl</strong><dd><code>Implement find_first_not_of methods with optimizations</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/core/fix_string.inl

<ul><li>Implement four <code>find_first_not_of</code> method overloads for different <br>parameter types<br> <li> Add <code>_find_first_not_of_raw</code> helper implementation with optimized lookup <br>table for multiple characters<br> <li> Include null pointer assertion for C string variant</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/89/files#diff-a47dfdd2a0becc17f40499abd90d00211a258ffaea3ce144fd5fc11d5ad08afd">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fix_string_test.cpp</strong><dd><code>Add comprehensive find_first_not_of test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/core/fix_string_test.cpp

<ul><li>Add comprehensive test suite for <code>find_first_not_of</code> methods covering <br>all overloads<br> <li> Test edge cases including empty strings, position parameters, and <br>special characters<br> <li> Remove unused array include</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/89/files#diff-cc1ff39c1921067e1cd9ffcf0bc8c8f3d7349f0178f1eb6ddeac099bc0a2d2ae">+185/-2</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.cpp</strong><dd><code>Remove unused array include</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/utils.cpp

- Remove unused `#include <array>` directive


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/89/files#diff-b7299fe3edc80d78917b9933233e3ffcc87145107cd31450980a018022faab85">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>core_utils_test.cpp</strong><dd><code>Remove unused array include</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/core/core_utils_test.cpp

- Remove unused `#include <array>` directive


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/89/files#diff-7095381a4499362722ee09ea2b94d60ee6849122fa1c20a6c37f59db537d042e">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakePresets.json</strong><dd><code>Configure macOS debug preset to stop on failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakePresets.json

<ul><li>Add <code>stopOnFailure: true</code> execution setting to macos-ninja-debug preset</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/89/files#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>core.hpp.in</strong><dd><code>Add array include to core header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/core.hpp.in

- Add `#include <array>` to header includes


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/89/files#diff-ebeff679f3b46ed6304ddd3b447e05c60fcfa5f7c5e989efc2b3598afb8ce16e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-07 04:44:27 UTC

This pull request implements the `find_first_not_of` method family for the FixString class, completing its standard library string compatibility by adding functionality to search for the first character not found in a specified set of characters. The implementation follows established patterns in the codebase by providing four method overloads: one for FixString objects, one for StringLike template objects, one for C-strings, and one for single characters.

The core implementation uses an optimized approach with a private helper method `_find_first_not_of_raw` that employs a boolean lookup table (`std::array<bool, 256>`) for efficient multi-character searches and a simple comparison loop for single-character searches. This design maintains O(n) time complexity while providing good performance characteristics that match existing search methods in the FixString class.

As part of this implementation, the PR includes several ancillary changes: adding `#include <array>` to the core header file to support the new functionality, removing redundant array includes from source files that were already getting the header transitively, comprehensive test coverage with 23 different test scenarios, and corrections to precondition documentation for existing search methods. Additionally, the macOS debug test preset was modified to stop on first failure, likely to aid in debugging during development.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `CMakePresets.json` | 4/5 | Added `stopOnFailure: true` to macOS debug test preset, creating platform inconsistency |
| `test/core/core_utils_test.cpp` | 4/5 | Removed redundant `#include <array>` that was available through transitive includes |
| `test/core/fix_string_test.cpp` | 5/5 | Added comprehensive test suite for `find_first_not_of` with 23 test scenarios |
| `src/core/utils.cpp` | 5/5 | Cleaned up redundant `#include <array>` already provided by core.hpp |
| `include/core/fix_string.inl` | 5/5 | Implemented `find_first_not_of` methods and optimized helper function |
| `include/core/fix_string.hpp` | 4/5 | Added method declarations and corrected precondition documentation for search methods |
| `src/core/core.hpp.in` | 5/5 | Added necessary `#include <array>` to support new string functionality |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk of breaking existing functionality
- Score reflects well-tested implementation with comprehensive coverage, but minor inconsistencies in platform configuration and documentation corrections need attention
- Pay close attention to `CMakePresets.json` for potential CI workflow differences and verify the precondition documentation changes in `fix_string.hpp` are accurate

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant FixString
    participant _find_first_not_of_raw
    participant LookupTable
    
    User->>FixString: "find_first_not_of(chars, position)"
    FixString->>FixString: "Validate position < _size"
    alt position >= _size
        FixString-->>User: "return npos"
    else dataSize == 0
        FixString-->>User: "return position"
    else dataSize == 1
        FixString->>FixString: "Loop through string from position"
        FixString->>FixString: "Check if _data[i] != exclude character"
        alt character not equal to exclude
            FixString-->>User: "return i"
        else
            FixString-->>User: "return npos"
        end
    else dataSize > 1
        FixString->>_find_first_not_of_raw: "_find_first_not_of_raw(position, data, dataSize)"
        _find_first_not_of_raw->>LookupTable: "Create lookup table (256 bools)"
        _find_first_not_of_raw->>LookupTable: "Set all entries to true"
        _find_first_not_of_raw->>LookupTable: "Set exclude characters to false"
        _find_first_not_of_raw->>_find_first_not_of_raw: "Loop through string from position"
        _find_first_not_of_raw->>LookupTable: "Check lookup[_data[i]]"
        alt lookup returns true
            _find_first_not_of_raw-->>FixString: "return i"
        else
            _find_first_not_of_raw-->>FixString: "return npos"
        end
        FixString-->>User: "return result"
    end
```

<!-- /greptile_comment -->