### PR TITLE
chore(core): refactor CStringView - modernize constructors, remove redundant const qualifiers, and improve documentation

### DIFF
--- a/include/core/c_string_view.hpp
+++ b/include/core/c_string_view.hpp
@@ -39,20 +39,20 @@ public:
   /*!
     \brief Constructs a copy of \a string view.
 
-    This constructor initializes a string view by copying the C-style string pointer from another \a string view.
+    This constructor initializes a string view by copying the C string pointer from another \a string view.
 
-    \param string The source string view to copy C-style string pointer from.
+    \param string The source string view to copy C string pointer from.
 
     \pre The source \a string view must be valid and properly initialized.
   */
-  constexpr CStringView(const CStringView & string) noexcept;
+  constexpr CStringView(const CStringView & string) noexcept = default;
 
   /*!
-    \brief Constructs a string view from a C-style \a string view.
+    \brief Constructs a string view from a C \a string.
 
-    Creates a new CStringView object that wraps the provided C-style \a string pointer.
+    Creates a new string view that wraps the provided C \a string pointer.
 
-    \param string The C-style string to wrap.
+    \param string The C string to wrap.
 
     \pre The source C \a string must not be null.
     \pre The source C \a string must be null-terminated.
@@ -69,20 +69,20 @@ public:
   /*!
     \brief Copy assigns other \a string view to this string view.
 
-    This operator assigns the C-style string pointer of another \a string view to this string view.
+    This operator assigns the C string pointer of another \a string view to this string view.
 
-    \param string The source string view to copy C-style string pointer from.
+    \param string The source string view to copy C string pointer from.
 
     \return A reference to this string view after assignment.
   */
-  constexpr CStringView & operator=(const CStringView & string) noexcept;
+  constexpr CStringView & operator=(const CStringView & string) noexcept = default;
 
   /*!
     \brief Copy assigns the C \a string to this string view.
 
     This operator assigns a new C \a string to this string view.
 
-    \param string The C-style string to assign.
+    \param string The C string to assign.
 
     \return A reference to this string view after assignment.
 
@@ -94,9 +94,9 @@ public:
   /*!
     \brief Copy assigns other \a string view to this string view.
 
-    This method assigns the C-style string pointer of another \a string view to this string view.
+    This method assigns the C string pointer of another \a string view to this string view.
 
-    \param string The source string view to copy C-style string pointer from.
+    \param string The source string view to copy C string pointer from.
 
     \return A reference to this string view after assignment.
 
@@ -111,7 +111,7 @@ public:
 
     This method assigns a new C \a string to this string view.
 
-    \param string The C-style string to assign.
+    \param string The C string to assign.
 
     \return A reference to this string view after assignment.
 
@@ -299,10 +299,10 @@ public:
   constexpr void clear() noexcept;
 
 private:
-  /// Pointer to the wrapped C-style string
+  /// Pointer to the wrapped C string
   const char * _data;
 
-  /// Static empty C-style string used as default value for null pointers
+  /// Static empty C string used as default value for null pointers
   static constexpr char _emptyString[]{'\0'};
 };
 

--- a/include/core/c_string_view.inl
+++ b/include/core/c_string_view.inl
@@ -30,18 +30,9 @@ namespace toy {
 constexpr CStringView::CStringView() noexcept
   : _data(_emptyString) {};
 
-constexpr CStringView::CStringView(const CStringView & string) noexcept
-  : _data(string._data) {}
-
 constexpr CStringView::CStringView(const char * string) noexcept
   : _data(string) {
   assert_message(string != nullptr, "String pointer must not be null");
-}
-
-constexpr CStringView & CStringView::operator=(const CStringView & string) noexcept {
-  _data = string._data;
-
-  return *this;
 }
 
 constexpr CStringView & CStringView::operator=(const char * string) noexcept {

--- a/test/core/c_string_view_test.cpp
+++ b/test/core/c_string_view_test.cpp
@@ -839,18 +839,18 @@ TEST_CASE("CStringView empty method", "[core][c_string_view]") {
   }
 
   SECTION("Numeric content") {
-    constexpr CStringView numeriCStringView("12345");
+    constexpr CStringView numericStringView("12345");
     constexpr CStringView floatString("3.14159");
     constexpr CStringView hexString("0xABCD");
     constexpr CStringView emptyString("");
 
-    REQUIRE_FALSE(numeriCStringView.empty());
+    REQUIRE_FALSE(numericStringView.empty());
     REQUIRE_FALSE(floatString.empty());
     REQUIRE_FALSE(hexString.empty());
     REQUIRE(emptyString.empty());
 
     // Compile-time checks
-    STATIC_REQUIRE_FALSE(numeriCStringView.empty());
+    STATIC_REQUIRE_FALSE(numericStringView.empty());
     STATIC_REQUIRE_FALSE(floatString.empty());
     STATIC_REQUIRE_FALSE(hexString.empty());
     STATIC_REQUIRE(emptyString.empty());
@@ -1008,18 +1008,18 @@ TEST_CASE("CStringView size method", "[core][c_string_view]") {
   }
 
   SECTION("Numeric content") {
-    constexpr CStringView numeriCStringView("12345");
+    constexpr CStringView numericStringView("12345");
     constexpr CStringView floatString("3.14159");
     constexpr CStringView hexString("0xABCD");
     constexpr CStringView emptyString("");
 
-    REQUIRE(numeriCStringView.size() == 5);
+    REQUIRE(numericStringView.size() == 5);
     REQUIRE(floatString.size() == 7);
     REQUIRE(hexString.size() == 6);
     REQUIRE(emptyString.size() == 0);
 
     // Compile-time checks
-    STATIC_REQUIRE(numeriCStringView.size() == 5);
+    STATIC_REQUIRE(numericStringView.size() == 5);
     STATIC_REQUIRE(floatString.size() == 7);
     STATIC_REQUIRE(hexString.size() == 6);
     STATIC_REQUIRE(emptyString.size() == 0);
@@ -1103,10 +1103,10 @@ TEST_CASE("CStringView utf8_size", "[core][c_string_view]") {
                                                         char(0xD1), char(0x82), char(0x20), char(0xD0), char(0xBC),
                                                         char(0xD0), char(0xB8), char(0xD1), char(0x80), char(0x00)}};
 
-    constexpr CStringView cyrilliCStringView(cyrillicText.data());
+    constexpr CStringView cyrillicStringView(cyrillicText.data());
 
-    REQUIRE(cyrilliCStringView.size() == 19);
-    REQUIRE(cyrilliCStringView.utf8_size() == 10);
+    REQUIRE(cyrillicStringView.size() == 19);
+    REQUIRE(cyrillicStringView.utf8_size() == 10);
   }
 
   SECTION("Mixed ASCII and UTF-8") {
@@ -1135,16 +1135,16 @@ TEST_CASE("CStringView utf8_size", "[core][c_string_view]") {
 
   SECTION("Special characters") {
     constexpr CStringView specialString("!@#$%^&*()");
-    constexpr CStringView numeriCStringView("1234567890");
+    constexpr CStringView numericStringView("1234567890");
     constexpr CStringView punctuationString(".,;:!?");
 
     REQUIRE(specialString.utf8_size() == 10);
-    REQUIRE(numeriCStringView.utf8_size() == 10);
+    REQUIRE(numericStringView.utf8_size() == 10);
     REQUIRE(punctuationString.utf8_size() == 6);
 
     // Special characters are ASCII, so utf8_size equals size
     REQUIRE(specialString.utf8_size() == specialString.size());
-    REQUIRE(numeriCStringView.utf8_size() == numeriCStringView.size());
+    REQUIRE(numericStringView.utf8_size() == numericStringView.size());
     REQUIRE(punctuationString.utf8_size() == punctuationString.size());
   }
 
@@ -1272,23 +1272,23 @@ TEST_CASE("CStringView length", "[core][c_string_view]") {
   }
 
   SECTION("Numeric content") {
-    constexpr CStringView numeriCStringView("12345");
+    constexpr CStringView numericStringView("12345");
     constexpr CStringView floatString("3.14159");
     constexpr CStringView hexString("0xABCD");
     constexpr CStringView emptyString("");
 
-    REQUIRE(numeriCStringView.length() == 5);
+    REQUIRE(numericStringView.length() == 5);
     REQUIRE(floatString.length() == 7);
     REQUIRE(hexString.length() == 6);
     REQUIRE(emptyString.length() == 0);
 
     // length() should equal size() for all strings
-    REQUIRE(numeriCStringView.length() == numeriCStringView.size());
+    REQUIRE(numericStringView.length() == numericStringView.size());
     REQUIRE(floatString.length() == floatString.size());
     REQUIRE(hexString.length() == hexString.size());
     REQUIRE(emptyString.length() == emptyString.size());
 
-    STATIC_REQUIRE(numeriCStringView.length() == 5);
+    STATIC_REQUIRE(numericStringView.length() == 5);
     STATIC_REQUIRE(floatString.length() == 7);
     STATIC_REQUIRE(hexString.length() == 6);
   }

--- a/test/core/c_string_view_test.cpp
+++ b/test/core/c_string_view_test.cpp
@@ -26,7 +26,7 @@ using namespace toy;
 
 TEST_CASE("CStringView constructors", "[core][c_string_view]") {
   SECTION("Default constructor") {
-    constexpr const CStringView emptyStr;
+    constexpr CStringView emptyStr;
 
     REQUIRE(emptyStr.size() == 0);
     REQUIRE(std::strcmp(emptyStr.c_str(), "") == 0);
@@ -37,10 +37,10 @@ TEST_CASE("CStringView constructors", "[core][c_string_view]") {
   }
 
   SECTION("Copy constructor") {
-    constexpr const CStringView original("CopyTest");
-    constexpr const CStringView copy1(original);
-    constexpr const CStringView copy2(original);
-    constexpr const CStringView copy3(original);
+    constexpr CStringView original("CopyTest");
+    constexpr CStringView copy1(original);
+    constexpr CStringView copy2(original);
+    constexpr CStringView copy3(original);
 
     REQUIRE(copy1.size() == 8);
     REQUIRE(std::strcmp(copy1.c_str(), "CopyTest") == 0);
@@ -58,10 +58,10 @@ TEST_CASE("CStringView constructors", "[core][c_string_view]") {
   }
 
   SECTION("C string constructor") {
-    constexpr const CStringView str1("Hello");
-    constexpr const CStringView str2("World");
-    constexpr const CStringView str3("Test");
-    constexpr const CStringView str4("This is a longer string for testing");
+    constexpr CStringView str1("Hello");
+    constexpr CStringView str2("World");
+    constexpr CStringView str3("Test");
+    constexpr CStringView str4("This is a longer string for testing");
 
     REQUIRE(str1.size() == 5);
     REQUIRE(std::strcmp(str1.c_str(), "Hello") == 0);
@@ -85,8 +85,8 @@ TEST_CASE("CStringView constructors", "[core][c_string_view]") {
 
   SECTION("Edge cases") {
     // Empty string
-    constexpr const CStringView empty1("");
-    constexpr const CStringView empty2("");
+    constexpr CStringView empty1("");
+    constexpr CStringView empty2("");
 
     REQUIRE(empty1.size() == 0);
     REQUIRE(empty2.size() == 0);
@@ -95,7 +95,7 @@ TEST_CASE("CStringView constructors", "[core][c_string_view]") {
     STATIC_REQUIRE(empty2.size() == 0);
 
     // Single character
-    constexpr const CStringView single("X");
+    constexpr CStringView single("X");
 
     REQUIRE(single.size() == 1);
     REQUIRE(std::strcmp(single.c_str(), "X") == 0);
@@ -105,9 +105,9 @@ TEST_CASE("CStringView constructors", "[core][c_string_view]") {
   }
 
   SECTION("Special characters") {
-    constexpr const CStringView newline("Line1\nLine2");
-    constexpr const CStringView tab("Col1\tCol2");
-    constexpr const CStringView mixed("Mix\t\nEnd");
+    constexpr CStringView newline("Line1\nLine2");
+    constexpr CStringView tab("Col1\tCol2");
+    constexpr CStringView mixed("Mix\t\nEnd");
 
     REQUIRE(newline.size() == 11);
     REQUIRE(std::strcmp(newline.c_str(), "Line1\nLine2") == 0);
@@ -126,8 +126,8 @@ TEST_CASE("CStringView constructors", "[core][c_string_view]") {
   }
 
   SECTION("Unicode content") {
-    constexpr const CStringView unicode("Привет мир");
-    constexpr const CStringView emoji("Hello 🌍");
+    constexpr CStringView unicode("Привет мир");
+    constexpr CStringView emoji("Hello 🌍");
 
     REQUIRE(unicode.size() == 19); // UTF-8 bytes
     REQUIRE(std::strcmp(unicode.c_str(), "Привет мир") == 0);
@@ -170,7 +170,7 @@ TEST_CASE("CStringView operators=", "[core][c_string_view]") {
     REQUIRE(std::strcmp(str2.c_str(), "This is a longer string") == 0);
 
     // Compile-time checks
-    constexpr const CStringView constStr1 = "This is a longer string";
+    constexpr CStringView constStr1 = "This is a longer string";
     STATIC_REQUIRE(constStr1.size() == 23);
     STATIC_REQUIRE(cstrcmp(constStr1.c_str(), "This is a longer string") == 0);
   }
@@ -194,8 +194,8 @@ TEST_CASE("CStringView operators=", "[core][c_string_view]") {
     REQUIRE(std::strcmp(str1.c_str(), "Hello") == 0);
 
     // Compile-time checks
-    constexpr const CStringView constStr1("Hello");
-    constexpr const CStringView constStr2 = constStr1;
+    constexpr CStringView constStr1("Hello");
+    constexpr CStringView constStr2 = constStr1;
     STATIC_REQUIRE(constStr2.size() == 5);
     STATIC_REQUIRE(cstrcmp(constStr2.c_str(), "Hello") == 0);
   }
@@ -323,7 +323,7 @@ TEST_CASE("CStringView assign", "[core][c_string_view]") {
     REQUIRE(std::strcmp(str1.c_str(), "") == 0);
 
     // Compile-time checks
-    constexpr const CStringView constStr1("Hello");
+    constexpr CStringView constStr1("Hello");
     constexpr auto constStr2 = CStringView("World").assign(constStr1);
     constexpr auto constStr3 = CStringView().assign(constStr2);
     STATIC_REQUIRE(constStr2.size() == 5);
@@ -427,7 +427,7 @@ TEST_CASE("CStringView assign", "[core][c_string_view]") {
 
 TEST_CASE("CStringView at", "[core][c_string_view]") {
   SECTION("at() access") {
-    constexpr const CStringView str("World");
+    constexpr CStringView str("World");
 
     REQUIRE(str.at(0) == 'W');
     REQUIRE(str.at(1) == 'o');
@@ -444,7 +444,7 @@ TEST_CASE("CStringView at", "[core][c_string_view]") {
   }
 
   SECTION("empty string") {
-    constexpr const CStringView str;
+    constexpr CStringView str;
 
     REQUIRE(str.at(0) == '\0');
 
@@ -455,8 +455,8 @@ TEST_CASE("CStringView at", "[core][c_string_view]") {
 
 TEST_CASE("CStringView operator[]", "[core][c_string_view]") {
   SECTION("[] access") {
-    constexpr const CStringView str("Hello");
-    constexpr const CStringView longStr("VeryLongString");
+    constexpr CStringView str("Hello");
+    constexpr CStringView longStr("VeryLongString");
 
     // Read-only access
     REQUIRE(str[0] == 'H');
@@ -488,7 +488,7 @@ TEST_CASE("CStringView operator[]", "[core][c_string_view]") {
   }
 
   SECTION("empty string") {
-    constexpr const CStringView str;
+    constexpr CStringView str;
 
     REQUIRE(str[0] == '\0');
 
@@ -499,7 +499,7 @@ TEST_CASE("CStringView operator[]", "[core][c_string_view]") {
 
 TEST_CASE("CStringView front and back", "[core][c_string_view]") {
   SECTION("Front method") {
-    constexpr const CStringView testString("Hello World");
+    constexpr CStringView testString("Hello World");
 
     REQUIRE(testString.front() == 'H');
     REQUIRE(testString[0] == 'H');
@@ -508,7 +508,7 @@ TEST_CASE("CStringView front and back", "[core][c_string_view]") {
   }
 
   SECTION("Back method") {
-    constexpr const CStringView testString("Hello World");
+    constexpr CStringView testString("Hello World");
 
     REQUIRE(testString.back() == 'd');
     REQUIRE(testString[testString.size() - 1] == 'd');
@@ -517,7 +517,7 @@ TEST_CASE("CStringView front and back", "[core][c_string_view]") {
   }
 
   SECTION("Single character string") {
-    constexpr const CStringView testString("A");
+    constexpr CStringView testString("A");
 
     REQUIRE(testString.front() == 'A');
     REQUIRE(testString.back() == 'A');
@@ -529,14 +529,14 @@ TEST_CASE("CStringView front and back", "[core][c_string_view]") {
   }
 
   SECTION("Empty string") {
-    constexpr const CStringView testString;
+    constexpr CStringView testString;
 
     REQUIRE(testString.front() == '\0');
     STATIC_REQUIRE(testString.front() == '\0');
   }
 
   SECTION("Two character string") {
-    constexpr const CStringView testString("AB");
+    constexpr CStringView testString("AB");
 
     REQUIRE(testString.front() == 'A');
     REQUIRE(testString.back() == 'B');
@@ -548,14 +548,14 @@ TEST_CASE("CStringView front and back", "[core][c_string_view]") {
   }
 
   SECTION("Const references") {
-    constexpr const CStringView testString("Hello World");
+    constexpr CStringView testString("Hello World");
 
     STATIC_REQUIRE(testString.front() == 'H');
     STATIC_REQUIRE(testString.back() == 'd');
   }
 
   SECTION("Numeric content") {
-    constexpr const CStringView testString("12345");
+    constexpr CStringView testString("12345");
 
     REQUIRE(testString.front() == '1');
     REQUIRE(testString.back() == '5');
@@ -565,7 +565,7 @@ TEST_CASE("CStringView front and back", "[core][c_string_view]") {
   }
 
   SECTION("Mixed content") {
-    constexpr const CStringView testString("123Hello456");
+    constexpr CStringView testString("123Hello456");
 
     REQUIRE(testString.front() == '1');
     REQUIRE(testString.back() == '6');
@@ -575,7 +575,7 @@ TEST_CASE("CStringView front and back", "[core][c_string_view]") {
   }
 
   SECTION("Long strings") {
-    constexpr const CStringView testString("This is a very long string for performance testing");
+    constexpr CStringView testString("This is a very long string for performance testing");
 
     REQUIRE(testString.front() == 'T');
     REQUIRE(testString.back() == 'g');
@@ -585,7 +585,7 @@ TEST_CASE("CStringView front and back", "[core][c_string_view]") {
   }
 
   SECTION("Case sensitivity") {
-    constexpr const CStringView testString("Hello World");
+    constexpr CStringView testString("Hello World");
 
     REQUIRE(testString.front() == 'H'); // Uppercase
     REQUIRE(testString.back() == 'd'); // Lowercase
@@ -595,7 +595,7 @@ TEST_CASE("CStringView front and back", "[core][c_string_view]") {
   }
 
   SECTION("Whitespace handling") {
-    constexpr const CStringView testString(" Hello ");
+    constexpr CStringView testString(" Hello ");
 
     REQUIRE(testString.front() == ' ');
     REQUIRE(testString.back() == ' ');
@@ -605,9 +605,9 @@ TEST_CASE("CStringView front and back", "[core][c_string_view]") {
   }
 
   SECTION("Constexpr operations") {
-    constexpr const CStringView str1("Hello");
-    constexpr const CStringView str2("World");
-    constexpr const CStringView str3("Test");
+    constexpr CStringView str1("Hello");
+    constexpr CStringView str2("World");
+    constexpr CStringView str3("Test");
 
     // Compile-time front operations
     constexpr const char & front1 = str1.front();
@@ -631,9 +631,9 @@ TEST_CASE("CStringView front and back", "[core][c_string_view]") {
 
 TEST_CASE("CStringView data", "[core][c_string_view]") {
   SECTION("Basic data access") {
-    constexpr const CStringView testString("Hello World");
-    constexpr const CStringView emptyString("");
-    constexpr const CStringView singleChar("A");
+    constexpr CStringView testString("Hello World");
+    constexpr CStringView emptyString("");
+    constexpr CStringView singleChar("A");
 
     // Test that data() points to null-terminated string
     REQUIRE(std::strcmp(testString.data(), "Hello World") == 0);
@@ -647,9 +647,9 @@ TEST_CASE("CStringView data", "[core][c_string_view]") {
   }
 
   SECTION("Data pointer stability") {
-    constexpr const CStringView testString("Stability Test");
-    constexpr const CStringView copy1(testString);
-    constexpr const CStringView copy2(testString);
+    constexpr CStringView testString("Stability Test");
+    constexpr CStringView copy1(testString);
+    constexpr CStringView copy2(testString);
 
     // Test that data() returns consistent pointers
     REQUIRE(testString.data() == testString.data());
@@ -672,8 +672,8 @@ TEST_CASE("CStringView data", "[core][c_string_view]") {
   }
 
   SECTION("Empty string") {
-    constexpr const CStringView emptyString("");
-    constexpr const CStringView defaultString;
+    constexpr CStringView emptyString("");
+    constexpr CStringView defaultString;
 
     // Test data() with empty strings
     REQUIRE(std::strcmp(emptyString.data(), "") == 0);
@@ -687,9 +687,9 @@ TEST_CASE("CStringView data", "[core][c_string_view]") {
 
 TEST_CASE("CStringView c_str method", "[core][c_string_view]") {
   SECTION("Basic c_str access") {
-    constexpr const CStringView testString("Hello World");
-    constexpr const CStringView emptyString("");
-    constexpr const CStringView singleChar("A");
+    constexpr CStringView testString("Hello World");
+    constexpr CStringView emptyString("");
+    constexpr CStringView singleChar("A");
 
     // Test that c_str() returns the same as data()
     REQUIRE(testString.c_str() == testString.data());
@@ -712,9 +712,9 @@ TEST_CASE("CStringView c_str method", "[core][c_string_view]") {
   }
 
   SECTION("C string pointer stability") {
-    constexpr const CStringView testString("Stability Test");
-    constexpr const CStringView copy1(testString);
-    constexpr const CStringView copy2(testString);
+    constexpr CStringView testString("Stability Test");
+    constexpr CStringView copy1(testString);
+    constexpr CStringView copy2(testString);
 
     // Test that c_str() returns consistent pointers
     REQUIRE(testString.c_str() == testString.c_str());
@@ -737,8 +737,8 @@ TEST_CASE("CStringView c_str method", "[core][c_string_view]") {
   }
 
   SECTION("Empty string") {
-    constexpr const CStringView emptyString("");
-    constexpr const CStringView defaultString;
+    constexpr CStringView emptyString("");
+    constexpr CStringView defaultString;
 
     // Test c_str() with empty strings
     REQUIRE(std::strcmp(emptyString.c_str(), "") == 0);
@@ -752,9 +752,9 @@ TEST_CASE("CStringView c_str method", "[core][c_string_view]") {
 
 TEST_CASE("CStringView empty method", "[core][c_string_view]") {
   SECTION("Basic empty check") {
-    constexpr const CStringView nonEmptyString("Hello World");
-    constexpr const CStringView emptyString("");
-    constexpr const CStringView defaultString;
+    constexpr CStringView nonEmptyString("Hello World");
+    constexpr CStringView emptyString("");
+    constexpr CStringView defaultString;
 
     REQUIRE_FALSE(nonEmptyString.empty());
     REQUIRE(emptyString.empty());
@@ -767,8 +767,8 @@ TEST_CASE("CStringView empty method", "[core][c_string_view]") {
   }
 
   SECTION("Single character strings") {
-    constexpr const CStringView singleChar("A");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView singleChar("A");
+    constexpr CStringView emptyString("");
 
     REQUIRE_FALSE(singleChar.empty());
     REQUIRE(emptyString.empty());
@@ -779,12 +779,12 @@ TEST_CASE("CStringView empty method", "[core][c_string_view]") {
   }
 
   SECTION("Different capacities") {
-    constexpr const CStringView smallString("Hi");
-    constexpr const CStringView mediumString("Hello World");
-    constexpr const CStringView largeString("This is a longer string");
-    constexpr const CStringView emptySmall("");
-    constexpr const CStringView emptyMedium("");
-    constexpr const CStringView emptyLarge("");
+    constexpr CStringView smallString("Hi");
+    constexpr CStringView mediumString("Hello World");
+    constexpr CStringView largeString("This is a longer string");
+    constexpr CStringView emptySmall("");
+    constexpr CStringView emptyMedium("");
+    constexpr CStringView emptyLarge("");
 
     REQUIRE_FALSE(smallString.empty());
     REQUIRE_FALSE(mediumString.empty());
@@ -803,10 +803,10 @@ TEST_CASE("CStringView empty method", "[core][c_string_view]") {
   }
 
   SECTION("Special characters") {
-    constexpr const CStringView newlineString("Hello\nWorld");
-    constexpr const CStringView tabString("Hello\tWorld");
-    constexpr const CStringView specialString("!@#$%^&*()");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView newlineString("Hello\nWorld");
+    constexpr CStringView tabString("Hello\tWorld");
+    constexpr CStringView specialString("!@#$%^&*()");
+    constexpr CStringView emptyString("");
 
     REQUIRE_FALSE(newlineString.empty());
     REQUIRE_FALSE(tabString.empty());
@@ -821,10 +821,10 @@ TEST_CASE("CStringView empty method", "[core][c_string_view]") {
   }
 
   SECTION("Unicode content") {
-    constexpr const CStringView unicodeString("Привет мир");
-    constexpr const CStringView emojiString("Hello 🌍 World");
-    constexpr const CStringView mixedString("Hello 世界");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView unicodeString("Привет мир");
+    constexpr CStringView emojiString("Hello 🌍 World");
+    constexpr CStringView mixedString("Hello 世界");
+    constexpr CStringView emptyString("");
 
     REQUIRE_FALSE(unicodeString.empty());
     REQUIRE_FALSE(emojiString.empty());
@@ -839,10 +839,10 @@ TEST_CASE("CStringView empty method", "[core][c_string_view]") {
   }
 
   SECTION("Numeric content") {
-    constexpr const CStringView numeriCStringView("12345");
-    constexpr const CStringView floatString("3.14159");
-    constexpr const CStringView hexString("0xABCD");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView numeriCStringView("12345");
+    constexpr CStringView floatString("3.14159");
+    constexpr CStringView hexString("0xABCD");
+    constexpr CStringView emptyString("");
 
     REQUIRE_FALSE(numeriCStringView.empty());
     REQUIRE_FALSE(floatString.empty());
@@ -857,10 +857,10 @@ TEST_CASE("CStringView empty method", "[core][c_string_view]") {
   }
 
   SECTION("Mixed content") {
-    constexpr const CStringView mixedString("Hello123World!@#");
-    constexpr const CStringView complexString("Test\n123\t!@#");
-    constexpr const CStringView longString("This is a very long string with mixed content 123!@#");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView mixedString("Hello123World!@#");
+    constexpr CStringView complexString("Test\n123\t!@#");
+    constexpr CStringView longString("This is a very long string with mixed content 123!@#");
+    constexpr CStringView emptyString("");
 
     REQUIRE_FALSE(mixedString.empty());
     REQUIRE_FALSE(complexString.empty());
@@ -875,10 +875,10 @@ TEST_CASE("CStringView empty method", "[core][c_string_view]") {
   }
 
   SECTION("Maximum length strings") {
-    constexpr const CStringView maxString("123456789012345"); // 15 characters
-    constexpr const CStringView maxSmall("1234567"); // 7 characters
-    constexpr const CStringView maxTiny("123"); // 3 characters
-    constexpr const CStringView emptyString("");
+    constexpr CStringView maxString("123456789012345"); // 15 characters
+    constexpr CStringView maxSmall("1234567"); // 7 characters
+    constexpr CStringView maxTiny("123"); // 3 characters
+    constexpr CStringView emptyString("");
 
     REQUIRE_FALSE(maxString.empty());
     REQUIRE_FALSE(maxSmall.empty());
@@ -893,10 +893,10 @@ TEST_CASE("CStringView empty method", "[core][c_string_view]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const CStringView singleChar("A");
-    constexpr const CStringView twoChars("AB");
-    constexpr const CStringView emptyString("");
-    constexpr const CStringView defaultString;
+    constexpr CStringView singleChar("A");
+    constexpr CStringView twoChars("AB");
+    constexpr CStringView emptyString("");
+    constexpr CStringView defaultString;
 
     REQUIRE_FALSE(singleChar.empty());
     REQUIRE_FALSE(twoChars.empty());
@@ -921,9 +921,9 @@ TEST_CASE("CStringView empty method", "[core][c_string_view]") {
 
 TEST_CASE("CStringView size method", "[core][c_string_view]") {
   SECTION("Basic size check") {
-    constexpr const CStringView testString("Hello World");
-    constexpr const CStringView emptyString("");
-    constexpr const CStringView defaultString;
+    constexpr CStringView testString("Hello World");
+    constexpr CStringView emptyString("");
+    constexpr CStringView defaultString;
 
     REQUIRE(testString.size() == 11);
     REQUIRE(emptyString.size() == 0);
@@ -936,8 +936,8 @@ TEST_CASE("CStringView size method", "[core][c_string_view]") {
   }
 
   SECTION("Single character strings") {
-    constexpr const CStringView singleChar("A");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView singleChar("A");
+    constexpr CStringView emptyString("");
 
     REQUIRE(singleChar.size() == 1);
     REQUIRE(emptyString.size() == 0);
@@ -948,12 +948,12 @@ TEST_CASE("CStringView size method", "[core][c_string_view]") {
   }
 
   SECTION("Different capacities") {
-    constexpr const CStringView smallString("Hi");
-    constexpr const CStringView mediumString("Hello World");
-    constexpr const CStringView largeString("This is a longer string");
-    constexpr const CStringView emptySmall("");
-    constexpr const CStringView emptyMedium("");
-    constexpr const CStringView emptyLarge("");
+    constexpr CStringView smallString("Hi");
+    constexpr CStringView mediumString("Hello World");
+    constexpr CStringView largeString("This is a longer string");
+    constexpr CStringView emptySmall("");
+    constexpr CStringView emptyMedium("");
+    constexpr CStringView emptyLarge("");
 
     REQUIRE(smallString.size() == 2);
     REQUIRE(mediumString.size() == 11);
@@ -972,10 +972,10 @@ TEST_CASE("CStringView size method", "[core][c_string_view]") {
   }
 
   SECTION("Special characters") {
-    constexpr const CStringView newlineString("Hello\nWorld");
-    constexpr const CStringView tabString("Hello\tWorld");
-    constexpr const CStringView specialString("!@#$%^&*()");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView newlineString("Hello\nWorld");
+    constexpr CStringView tabString("Hello\tWorld");
+    constexpr CStringView specialString("!@#$%^&*()");
+    constexpr CStringView emptyString("");
 
     REQUIRE(newlineString.size() == 11);
     REQUIRE(tabString.size() == 11);
@@ -990,10 +990,10 @@ TEST_CASE("CStringView size method", "[core][c_string_view]") {
   }
 
   SECTION("Unicode content") {
-    constexpr const CStringView unicodeString("Привет мир");
-    constexpr const CStringView emojiString("Hello 🌍 World");
-    constexpr const CStringView mixedString("Hello 世界");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView unicodeString("Привет мир");
+    constexpr CStringView emojiString("Hello 🌍 World");
+    constexpr CStringView mixedString("Hello 世界");
+    constexpr CStringView emptyString("");
 
     REQUIRE(unicodeString.size() == 19);
     REQUIRE(emojiString.size() == 16);
@@ -1008,10 +1008,10 @@ TEST_CASE("CStringView size method", "[core][c_string_view]") {
   }
 
   SECTION("Numeric content") {
-    constexpr const CStringView numeriCStringView("12345");
-    constexpr const CStringView floatString("3.14159");
-    constexpr const CStringView hexString("0xABCD");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView numeriCStringView("12345");
+    constexpr CStringView floatString("3.14159");
+    constexpr CStringView hexString("0xABCD");
+    constexpr CStringView emptyString("");
 
     REQUIRE(numeriCStringView.size() == 5);
     REQUIRE(floatString.size() == 7);
@@ -1026,10 +1026,10 @@ TEST_CASE("CStringView size method", "[core][c_string_view]") {
   }
 
   SECTION("Mixed content") {
-    constexpr const CStringView mixedString("Hello123World!@#");
-    constexpr const CStringView complexString("Test\n123\t!@#");
-    constexpr const CStringView longString("This is a very long string with mixed content 123!@#");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView mixedString("Hello123World!@#");
+    constexpr CStringView complexString("Test\n123\t!@#");
+    constexpr CStringView longString("This is a very long string with mixed content 123!@#");
+    constexpr CStringView emptyString("");
 
     REQUIRE(mixedString.size() == 16);
     REQUIRE(complexString.size() == 12);
@@ -1044,10 +1044,10 @@ TEST_CASE("CStringView size method", "[core][c_string_view]") {
   }
 
   SECTION("Maximum length strings") {
-    constexpr const CStringView maxString("123456789012345"); // 15 characters
-    constexpr const CStringView maxSmall("1234567"); // 7 characters
-    constexpr const CStringView maxTiny("123"); // 3 characters
-    constexpr const CStringView emptyString("");
+    constexpr CStringView maxString("123456789012345"); // 15 characters
+    constexpr CStringView maxSmall("1234567"); // 7 characters
+    constexpr CStringView maxTiny("123"); // 3 characters
+    constexpr CStringView emptyString("");
 
     REQUIRE(maxString.size() == 15);
     REQUIRE(maxSmall.size() == 7);
@@ -1062,10 +1062,10 @@ TEST_CASE("CStringView size method", "[core][c_string_view]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const CStringView singleChar("A");
-    constexpr const CStringView twoChars("AB");
-    constexpr const CStringView emptyString("");
-    constexpr const CStringView defaultString;
+    constexpr CStringView singleChar("A");
+    constexpr CStringView twoChars("AB");
+    constexpr CStringView emptyString("");
+    constexpr CStringView defaultString;
 
     REQUIRE(singleChar.size() == 1);
     REQUIRE(twoChars.size() == 2);
@@ -1082,9 +1082,9 @@ TEST_CASE("CStringView size method", "[core][c_string_view]") {
 
 TEST_CASE("CStringView utf8_size", "[core][c_string_view]") {
   SECTION("ASCII strings") {
-    constexpr const CStringView asciiString("Hello World");
-    constexpr const CStringView emptyString("");
-    constexpr const CStringView singleChar("A");
+    constexpr CStringView asciiString("Hello World");
+    constexpr CStringView emptyString("");
+    constexpr CStringView singleChar("A");
 
     REQUIRE(asciiString.utf8_size() == 11);
     REQUIRE(emptyString.utf8_size() == 0);
@@ -1103,7 +1103,7 @@ TEST_CASE("CStringView utf8_size", "[core][c_string_view]") {
                                                         char(0xD1), char(0x82), char(0x20), char(0xD0), char(0xBC),
                                                         char(0xD0), char(0xB8), char(0xD1), char(0x80), char(0x00)}};
 
-    constexpr const CStringView cyrilliCStringView(cyrillicText.data());
+    constexpr CStringView cyrilliCStringView(cyrillicText.data());
 
     REQUIRE(cyrilliCStringView.size() == 19);
     REQUIRE(cyrilliCStringView.utf8_size() == 10);
@@ -1115,7 +1115,7 @@ TEST_CASE("CStringView utf8_size", "[core][c_string_view]") {
                                                      char(0x20), char(0xE4), char(0xB8), char(0x96), char(0xE7),
                                                      char(0x95), char(0x8C), char(0x00)}};
 
-    constexpr const CStringView mixedString(mixedText.data());
+    constexpr CStringView mixedString(mixedText.data());
 
     REQUIRE(mixedString.size() == 12);
     REQUIRE(mixedString.utf8_size() == 8); // 6 ASCII + 2 Chinese characters
@@ -1127,16 +1127,16 @@ TEST_CASE("CStringView utf8_size", "[core][c_string_view]") {
                                                      char(0x20), char(0xF0), char(0x9F), char(0x8C), char(0x8D),
                                                      char(0x00)}};
 
-    constexpr const CStringView emojiString(emojiText.data());
+    constexpr CStringView emojiString(emojiText.data());
 
     REQUIRE(emojiString.size() == 10);
     REQUIRE(emojiString.utf8_size() == 7); // 6 ASCII + 1 emoji
   }
 
   SECTION("Special characters") {
-    constexpr const CStringView specialString("!@#$%^&*()");
-    constexpr const CStringView numeriCStringView("1234567890");
-    constexpr const CStringView punctuationString(".,;:!?");
+    constexpr CStringView specialString("!@#$%^&*()");
+    constexpr CStringView numeriCStringView("1234567890");
+    constexpr CStringView punctuationString(".,;:!?");
 
     REQUIRE(specialString.utf8_size() == 10);
     REQUIRE(numeriCStringView.utf8_size() == 10);
@@ -1149,10 +1149,10 @@ TEST_CASE("CStringView utf8_size", "[core][c_string_view]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const CStringView singleByte("A");
-    constexpr const CStringView twoByte("А"); // Cyrillic A
-    constexpr const CStringView threeByte("中"); // Chinese character
-    constexpr const CStringView fourByte("🌍"); // Emoji
+    constexpr CStringView singleByte("A");
+    constexpr CStringView twoByte("А"); // Cyrillic A
+    constexpr CStringView threeByte("中"); // Chinese character
+    constexpr CStringView fourByte("🌍"); // Emoji
 
     REQUIRE(singleByte.utf8_size() == 1);
     REQUIRE(twoByte.utf8_size() == 1);
@@ -1172,7 +1172,7 @@ TEST_CASE("CStringView utf8_size", "[core][c_string_view]") {
        char(0xB4), char(0xD0), char(0xB2), char(0xD0), char(0xB8), char(0xD0), char(0xB6), char(0xD0), char(0xBE),
        char(0xD0), char(0xBA), char(0x2E), char(0x00)}};
 
-    constexpr const CStringView longString(longUtf8Text.data());
+    constexpr CStringView longString(longUtf8Text.data());
 
     REQUIRE(longString.size() == 66); // 66 bytes
     REQUIRE(longString.utf8_size() == 43); // 43 characters
@@ -1181,9 +1181,9 @@ TEST_CASE("CStringView utf8_size", "[core][c_string_view]") {
 
 TEST_CASE("CStringView length", "[core][c_string_view]") {
   SECTION("Basic length check") {
-    constexpr const CStringView testString("Hello World");
-    constexpr const CStringView emptyString("");
-    constexpr const CStringView singleChar("A");
+    constexpr CStringView testString("Hello World");
+    constexpr CStringView emptyString("");
+    constexpr CStringView singleChar("A");
 
     REQUIRE(testString.length() == 11);
     REQUIRE(emptyString.length() == 0);
@@ -1200,12 +1200,12 @@ TEST_CASE("CStringView length", "[core][c_string_view]") {
   }
 
   SECTION("Different capacities") {
-    constexpr const CStringView smallString("Hi");
-    constexpr const CStringView mediumString("Hello World");
-    constexpr const CStringView largeString("This is a longer string");
-    constexpr const CStringView emptySmall("");
-    constexpr const CStringView emptyMedium("");
-    constexpr const CStringView emptyLarge("");
+    constexpr CStringView smallString("Hi");
+    constexpr CStringView mediumString("Hello World");
+    constexpr CStringView largeString("This is a longer string");
+    constexpr CStringView emptySmall("");
+    constexpr CStringView emptyMedium("");
+    constexpr CStringView emptyLarge("");
 
     REQUIRE(smallString.length() == 2);
     REQUIRE(mediumString.length() == 11);
@@ -1228,10 +1228,10 @@ TEST_CASE("CStringView length", "[core][c_string_view]") {
   }
 
   SECTION("Special characters") {
-    constexpr const CStringView newlineString("Hello\nWorld");
-    constexpr const CStringView tabString("Hello\tWorld");
-    constexpr const CStringView specialString("!@#$%^&*()");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView newlineString("Hello\nWorld");
+    constexpr CStringView tabString("Hello\tWorld");
+    constexpr CStringView specialString("!@#$%^&*()");
+    constexpr CStringView emptyString("");
 
     REQUIRE(newlineString.length() == 11);
     REQUIRE(tabString.length() == 11);
@@ -1250,10 +1250,10 @@ TEST_CASE("CStringView length", "[core][c_string_view]") {
   }
 
   SECTION("Unicode content") {
-    constexpr const CStringView unicodeString("Привет мир");
-    constexpr const CStringView emojiString("Hello 🌍 World");
-    constexpr const CStringView mixedString("Hello 世界");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView unicodeString("Привет мир");
+    constexpr CStringView emojiString("Hello 🌍 World");
+    constexpr CStringView mixedString("Hello 世界");
+    constexpr CStringView emptyString("");
 
     REQUIRE(unicodeString.length() == 19);
     REQUIRE(emojiString.length() == 16);
@@ -1272,10 +1272,10 @@ TEST_CASE("CStringView length", "[core][c_string_view]") {
   }
 
   SECTION("Numeric content") {
-    constexpr const CStringView numeriCStringView("12345");
-    constexpr const CStringView floatString("3.14159");
-    constexpr const CStringView hexString("0xABCD");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView numeriCStringView("12345");
+    constexpr CStringView floatString("3.14159");
+    constexpr CStringView hexString("0xABCD");
+    constexpr CStringView emptyString("");
 
     REQUIRE(numeriCStringView.length() == 5);
     REQUIRE(floatString.length() == 7);
@@ -1294,10 +1294,10 @@ TEST_CASE("CStringView length", "[core][c_string_view]") {
   }
 
   SECTION("Mixed content") {
-    constexpr const CStringView mixedString("Hello123World!@#");
-    constexpr const CStringView complexString("Test\n123\t!@#");
-    constexpr const CStringView longString("This is a very long string with mixed content 123!@#");
-    constexpr const CStringView emptyString("");
+    constexpr CStringView mixedString("Hello123World!@#");
+    constexpr CStringView complexString("Test\n123\t!@#");
+    constexpr CStringView longString("This is a very long string with mixed content 123!@#");
+    constexpr CStringView emptyString("");
 
     REQUIRE(mixedString.length() == 16);
     REQUIRE(complexString.length() == 12);
@@ -1316,10 +1316,10 @@ TEST_CASE("CStringView length", "[core][c_string_view]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const CStringView singleChar("A");
-    constexpr const CStringView twoChars("AB");
-    constexpr const CStringView emptyString("");
-    constexpr const CStringView defaultString;
+    constexpr CStringView singleChar("A");
+    constexpr CStringView twoChars("AB");
+    constexpr CStringView emptyString("");
+    constexpr CStringView defaultString;
 
     REQUIRE(singleChar.length() == 1);
     REQUIRE(twoChars.length() == 2);
@@ -1341,10 +1341,10 @@ TEST_CASE("CStringView length", "[core][c_string_view]") {
 
 TEST_CASE("CStringView max_size", "[core][c_string_view]") {
   SECTION("Basic max_size check") {
-    constexpr const CStringView smallString("Hi");
-    constexpr const CStringView mediumString("Hello World");
-    constexpr const CStringView largeString("This is a longer string");
-    constexpr const CStringView extraLargeString("This is an even longer string for testing");
+    constexpr CStringView smallString("Hi");
+    constexpr CStringView mediumString("Hello World");
+    constexpr CStringView largeString("This is a longer string");
+    constexpr CStringView extraLargeString("This is an even longer string for testing");
 
     REQUIRE(smallString.max_size() == 2);
     REQUIRE(mediumString.max_size() == 11);
@@ -1358,7 +1358,7 @@ TEST_CASE("CStringView max_size", "[core][c_string_view]") {
   }
 
   SECTION("Empty string") {
-    constexpr const CStringView empty("");
+    constexpr CStringView empty("");
 
     REQUIRE(empty.max_size() == 0);
 
@@ -1366,7 +1366,7 @@ TEST_CASE("CStringView max_size", "[core][c_string_view]") {
   }
 
   SECTION("Default constructed string") {
-    constexpr const CStringView defaultString;
+    constexpr CStringView defaultString;
 
     REQUIRE(defaultString.max_size() == 0);
 
@@ -1374,7 +1374,7 @@ TEST_CASE("CStringView max_size", "[core][c_string_view]") {
   }
 
   SECTION("Single character string") {
-    constexpr const CStringView single("A");
+    constexpr CStringView single("A");
 
     REQUIRE(single.max_size() == 1);
 
@@ -1384,10 +1384,10 @@ TEST_CASE("CStringView max_size", "[core][c_string_view]") {
 
 TEST_CASE("CStringView capacity", "[core][c_string_view]") {
   SECTION("Basic capacity check") {
-    constexpr const CStringView smallString("Hi");
-    constexpr const CStringView mediumString("Hello World");
-    constexpr const CStringView largeString("This is a longer string");
-    constexpr const CStringView extraLargeString("This is an even longer string for testing");
+    constexpr CStringView smallString("Hi");
+    constexpr CStringView mediumString("Hello World");
+    constexpr CStringView largeString("This is a longer string");
+    constexpr CStringView extraLargeString("This is an even longer string for testing");
 
     REQUIRE(smallString.capacity() == 2);
     REQUIRE(mediumString.capacity() == 11);
@@ -1401,7 +1401,7 @@ TEST_CASE("CStringView capacity", "[core][c_string_view]") {
   }
 
   SECTION("Empty string") {
-    constexpr const CStringView empty("");
+    constexpr CStringView empty("");
 
     REQUIRE(empty.capacity() == 0);
 
@@ -1409,7 +1409,7 @@ TEST_CASE("CStringView capacity", "[core][c_string_view]") {
   }
 
   SECTION("Default constructed string") {
-    constexpr const CStringView defaultString;
+    constexpr CStringView defaultString;
 
     REQUIRE(defaultString.capacity() == 0);
 
@@ -1417,7 +1417,7 @@ TEST_CASE("CStringView capacity", "[core][c_string_view]") {
   }
 
   SECTION("Single character string") {
-    constexpr const CStringView single("A");
+    constexpr CStringView single("A");
 
     REQUIRE(single.capacity() == 1);
 

--- a/test/core/fix_string_test.cpp
+++ b/test/core/fix_string_test.cpp
@@ -26,7 +26,7 @@ using namespace toy;
 
 TEST_CASE("FixedString constructors", "[core][fixed_string]") {
   SECTION("Default constructor") {
-    constexpr const FixedString<32> emptyStr;
+    constexpr FixedString<32> emptyStr;
 
     REQUIRE(emptyStr.size() == 0);
     REQUIRE(std::strcmp(emptyStr.c_str(), "") == 0);
@@ -41,10 +41,10 @@ TEST_CASE("FixedString constructors", "[core][fixed_string]") {
   }
 
   SECTION("C string constructor") {
-    constexpr const FixedString<16> str1("Hello");
-    constexpr const FixedString<32> str2("World");
-    constexpr const FixedString<8> str3("Test");
-    constexpr const FixedString<64> str4("This is a longer string for testing");
+    constexpr FixedString<16> str1("Hello");
+    constexpr FixedString<32> str2("World");
+    constexpr FixedString<8> str3("Test");
+    constexpr FixedString<64> str4("This is a longer string for testing");
 
     REQUIRE(str1.size() == 5);
     REQUIRE(std::strcmp(str1.c_str(), "Hello") == 0);
@@ -67,10 +67,10 @@ TEST_CASE("FixedString constructors", "[core][fixed_string]") {
   }
 
   SECTION("Copy constructor") {
-    constexpr const FixedString<16> original("CopyTest");
-    constexpr const FixedString<16> copy1(original);
-    constexpr const FixedString<32> copy2(original);
-    constexpr const FixedString<12> copy3(original);
+    constexpr FixedString<16> original("CopyTest");
+    constexpr FixedString<16> copy1(original);
+    constexpr FixedString<32> copy2(original);
+    constexpr FixedString<12> copy3(original);
 
     REQUIRE(copy1.size() == 8);
     REQUIRE(std::strcmp(copy1.c_str(), "CopyTest") == 0);
@@ -98,10 +98,10 @@ TEST_CASE("FixedString constructors", "[core][fixed_string]") {
   }
 
   SECTION("Character constructor") {
-    constexpr const FixedString<16> single('A');
-    constexpr const FixedString<32> multiple('B', 5);
-    constexpr const FixedString<8> many('C', 7);
-    constexpr const FixedString<64> empty('D', 0);
+    constexpr FixedString<16> single('A');
+    constexpr FixedString<32> multiple('B', 5);
+    constexpr FixedString<8> many('C', 7);
+    constexpr FixedString<64> empty('D', 0);
 
     REQUIRE(single.size() == 1);
     REQUIRE(std::strcmp(single.c_str(), "A") == 0);
@@ -136,8 +136,8 @@ TEST_CASE("FixedString constructors", "[core][fixed_string]") {
 
   SECTION("Edge cases") {
     // Empty string
-    constexpr const FixedString<16> empty1("");
-    constexpr const FixedString<32> empty2("");
+    constexpr FixedString<16> empty1("");
+    constexpr FixedString<32> empty2("");
 
     REQUIRE(empty1.size() == 0);
     REQUIRE(empty2.size() == 0);
@@ -146,7 +146,7 @@ TEST_CASE("FixedString constructors", "[core][fixed_string]") {
     STATIC_REQUIRE(empty2.size() == 0);
 
     // Single character
-    constexpr const FixedString<8> single("X");
+    constexpr FixedString<8> single("X");
 
     REQUIRE(single.size() == 1);
     REQUIRE(std::strcmp(single.c_str(), "X") == 0);
@@ -155,7 +155,7 @@ TEST_CASE("FixedString constructors", "[core][fixed_string]") {
     STATIC_REQUIRE(cstrcmp(single.c_str(), "X") == 0);
 
     // Maximum length
-    constexpr const FixedString<5> maxLen("Test");
+    constexpr FixedString<5> maxLen("Test");
 
     REQUIRE(maxLen.size() == 4);
     REQUIRE(std::strcmp(maxLen.c_str(), "Test") == 0);
@@ -166,9 +166,9 @@ TEST_CASE("FixedString constructors", "[core][fixed_string]") {
   }
 
   SECTION("Special characters") {
-    constexpr const FixedString<32> newline("Line1\nLine2");
-    constexpr const FixedString<32> tab("Col1\tCol2");
-    constexpr const FixedString<32> mixed("Mix\t\nEnd");
+    constexpr FixedString<32> newline("Line1\nLine2");
+    constexpr FixedString<32> tab("Col1\tCol2");
+    constexpr FixedString<32> mixed("Mix\t\nEnd");
 
     REQUIRE(newline.size() == 11);
     REQUIRE(std::strcmp(newline.c_str(), "Line1\nLine2") == 0);
@@ -187,8 +187,8 @@ TEST_CASE("FixedString constructors", "[core][fixed_string]") {
   }
 
   SECTION("Unicode content") {
-    constexpr const FixedString<64> unicode("Привет мир");
-    constexpr const FixedString<32> emoji("Hello 🌍");
+    constexpr FixedString<64> unicode("Привет мир");
+    constexpr FixedString<32> emoji("Hello 🌍");
 
     REQUIRE(unicode.size() == 19); // UTF-8 bytes
     REQUIRE(std::strcmp(unicode.c_str(), "Привет мир") == 0);
@@ -231,7 +231,7 @@ TEST_CASE("FixedString operators=", "[core][fixed_string]") {
     REQUIRE(std::strcmp(str2.c_str(), "This is a longer string") == 0);
 
     // Compile-time checks
-    constexpr const FixedString<24> constStr1 = "This is a longer string";
+    constexpr FixedString<24> constStr1 = "This is a longer string";
     STATIC_REQUIRE(constStr1.size() == 23);
     STATIC_REQUIRE(cstrcmp(constStr1.c_str(), "This is a longer string") == 0);
   }
@@ -255,8 +255,8 @@ TEST_CASE("FixedString operators=", "[core][fixed_string]") {
     REQUIRE(std::strcmp(str1.c_str(), "Hello") == 0);
 
     // Compile-time checks
-    constexpr const FixedString<24> constStr1("Hello");
-    constexpr const FixedString<24> constStr2 = constStr1;
+    constexpr FixedString<24> constStr1("Hello");
+    constexpr FixedString<24> constStr2 = constStr1;
     STATIC_REQUIRE(constStr2.size() == 5);
     STATIC_REQUIRE(cstrcmp(constStr2.c_str(), "Hello") == 0);
   }
@@ -280,9 +280,9 @@ TEST_CASE("FixedString operators=", "[core][fixed_string]") {
     REQUIRE(std::strcmp(str1.c_str(), "Test") == 0);
 
     // Compile-time checks
-    constexpr const FixedString<8> constStr1("Test");
-    constexpr const FixedString<32> constStr2 = constStr1;
-    constexpr const FixedString<16> constStr3 = constStr2;
+    constexpr FixedString<8> constStr1("Test");
+    constexpr FixedString<32> constStr2 = constStr1;
+    constexpr FixedString<16> constStr3 = constStr2;
     STATIC_REQUIRE(constStr2.size() == 4);
     STATIC_REQUIRE(cstrcmp(constStr2.c_str(), "Test") == 0);
     STATIC_REQUIRE(constStr3.size() == 4);
@@ -460,7 +460,7 @@ TEST_CASE("FixedString assign", "[core][fixed_string]") {
     REQUIRE(std::strcmp(str1.c_str(), "") == 0);
 
     // Compile-time checks
-    constexpr const FixedString<16> constStr1("Hello");
+    constexpr FixedString<16> constStr1("Hello");
     constexpr auto constStr2 = FixedString<16>("World").assign(constStr1);
     constexpr auto constStr3 = FixedString<16>().assign(constStr2);
     STATIC_REQUIRE(constStr2.size() == 5);
@@ -484,8 +484,8 @@ TEST_CASE("FixedString assign", "[core][fixed_string]") {
     REQUIRE(std::strcmp(str1.c_str(), "Hi") == 0);
 
     // Compile-time checks
-    constexpr const FixedString<8> constStr1("Hi");
-    constexpr const FixedString<16> constStr2("Hello");
+    constexpr FixedString<8> constStr1("Hi");
+    constexpr FixedString<16> constStr2("Hello");
     constexpr auto constStr3 = FixedString<8>("Hi").assign(constStr2);
     constexpr auto constStr4 = FixedString<16>("Hello").assign(constStr1);
     STATIC_REQUIRE(constStr3.size() == 5);
@@ -675,7 +675,7 @@ TEST_CASE("FixedString at", "[core][fixed_string]") {
   }
 
   SECTION("Const at() access") {
-    constexpr const FixedString<8> str("World");
+    constexpr FixedString<8> str("World");
 
     REQUIRE(str.at(0) == 'W');
     REQUIRE(str.at(1) == 'o');
@@ -692,7 +692,7 @@ TEST_CASE("FixedString at", "[core][fixed_string]") {
   }
 
   SECTION("empty string") {
-    constexpr const FixedString<8> str;
+    constexpr FixedString<8> str;
 
     REQUIRE(str.at(0) == '\0');
 
@@ -803,7 +803,7 @@ TEST_CASE("FixedString at", "[core][fixed_string]") {
 TEST_CASE("FixedString operator[]", "[core][fixed_string]") {
   SECTION("Non-const operator[] - basic access") {
     FixedString<16> str("Hello");
-    constexpr const FixedString<16> constStr("World");
+    constexpr FixedString<16> constStr("World");
 
     // Basic access
     REQUIRE(str[0] == 'H');
@@ -861,8 +861,8 @@ TEST_CASE("FixedString operator[]", "[core][fixed_string]") {
   }
 
   SECTION("Const operator[] - read-only access") {
-    constexpr const FixedString<16> str("Hello");
-    constexpr const FixedString<32> longStr("VeryLongString");
+    constexpr FixedString<16> str("Hello");
+    constexpr FixedString<32> longStr("VeryLongString");
 
     // Read-only access
     REQUIRE(str[0] == 'H');
@@ -893,7 +893,7 @@ TEST_CASE("FixedString operator[]", "[core][fixed_string]") {
 
   SECTION("Single character strings") {
     FixedString<8> str("A");
-    constexpr const FixedString<8> constStr("B");
+    constexpr FixedString<8> constStr("B");
 
     // Non-const access
     REQUIRE(str[0] == 'A');
@@ -910,7 +910,7 @@ TEST_CASE("FixedString operator[]", "[core][fixed_string]") {
 
   SECTION("Special characters") {
     FixedString<32> str("Hello\n\tWorld");
-    constexpr const FixedString<32> constStr("Test!@#$%");
+    constexpr FixedString<32> constStr("Test!@#$%");
 
     // Special characters
     REQUIRE(str[5] == '\n');
@@ -933,7 +933,7 @@ TEST_CASE("FixedString operator[]", "[core][fixed_string]") {
 
   SECTION("Unicode content") {
     FixedString<32> str("Hello 世界");
-    constexpr const FixedString<32> constStr("Test 🌍");
+    constexpr FixedString<32> constStr("Test 🌍");
 
     // Unicode characters (byte-level access)
     REQUIRE(str[5] == ' '); // Space
@@ -955,7 +955,7 @@ TEST_CASE("FixedString operator[]", "[core][fixed_string]") {
 
   SECTION("Edge cases") {
     FixedString<4> str("ABC"); // Maximum length for capacity 4
-    constexpr const FixedString<4> constStr("XYZ");
+    constexpr FixedString<4> constStr("XYZ");
 
     // Access to last character
     REQUIRE(str[2] == 'C');
@@ -999,7 +999,7 @@ TEST_CASE("FixedString operator[]", "[core][fixed_string]") {
   }
 
   SECTION("empty string") {
-    constexpr const FixedString<16> str;
+    constexpr FixedString<16> str;
 
     REQUIRE(str[0] == '\0');
 
@@ -1011,7 +1011,7 @@ TEST_CASE("FixedString operator[]", "[core][fixed_string]") {
 TEST_CASE("FixedString front and back", "[core][fixed_string]") {
   SECTION("Front method") {
     FixedString<16> testString("Hello World");
-    constexpr const FixedString<16> constString("Hello World");
+    constexpr FixedString<16> constString("Hello World");
 
     REQUIRE(testString.front() == 'H');
     REQUIRE(testString[0] == 'H');
@@ -1026,7 +1026,7 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
 
   SECTION("Back method") {
     FixedString<16> testString("Hello World");
-    constexpr const FixedString<16> constString("Hello World");
+    constexpr FixedString<16> constString("Hello World");
 
     REQUIRE(testString.back() == 'd');
     REQUIRE(testString[testString.size() - 1] == 'd');
@@ -1056,7 +1056,7 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
     REQUIRE(testString.back() == 'C');
 
     // Compile-time checks
-    constexpr const FixedString<2> constTestString("A");
+    constexpr FixedString<2> constTestString("A");
     STATIC_REQUIRE(constTestString.front() == 'A');
     STATIC_REQUIRE(constTestString.back() == 'A');
     STATIC_REQUIRE(constTestString.front() == constTestString.back());
@@ -1068,7 +1068,7 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
     REQUIRE(testString.front() == '\0');
 
     // Compile-time checks
-    constexpr const FixedString<16> constTestString("");
+    constexpr FixedString<16> constTestString("");
     STATIC_REQUIRE(constTestString.front() == '\0');
   }
 
@@ -1089,7 +1089,7 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
     REQUIRE(testString.back() == 'Y');
 
     // Compile-time checks
-    constexpr const FixedString<8> constTestString("AB");
+    constexpr FixedString<8> constTestString("AB");
     STATIC_REQUIRE(constTestString.front() == 'A');
     STATIC_REQUIRE(constTestString.back() == 'B');
     STATIC_REQUIRE(constTestString.front() != constTestString.back());
@@ -1112,7 +1112,7 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
   }
 
   SECTION("Const references") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     STATIC_REQUIRE(testString.front() == 'H');
     STATIC_REQUIRE(testString.back() == 'd');
@@ -1132,7 +1132,7 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
     REQUIRE(testString.back() == '\t');
 
     // Compile-time checks
-    constexpr const FixedString<16> constTestString("Hello\n\tWorld!");
+    constexpr FixedString<16> constTestString("Hello\n\tWorld!");
     STATIC_REQUIRE(constTestString.front() == 'H');
     STATIC_REQUIRE(constTestString.back() == '!');
   }
@@ -1151,7 +1151,7 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
     REQUIRE(testString.back() == '0');
 
     // Compile-time checks
-    constexpr const FixedString<16> constTestString("12345");
+    constexpr FixedString<16> constTestString("12345");
     STATIC_REQUIRE(constTestString.front() == '1');
     STATIC_REQUIRE(constTestString.back() == '5');
   }
@@ -1170,7 +1170,7 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
     REQUIRE(testString.back() == '0');
 
     // Compile-time checks
-    constexpr const FixedString<32> constTestString("123Hello456");
+    constexpr FixedString<32> constTestString("123Hello456");
     STATIC_REQUIRE(constTestString.front() == '1');
     STATIC_REQUIRE(constTestString.back() == '6');
   }
@@ -1189,7 +1189,7 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
     REQUIRE(testString.back() == 'Y');
 
     // Compile-time checks
-    constexpr const FixedString<64> constTestString("This is a very long string for performance testing");
+    constexpr FixedString<64> constTestString("This is a very long string for performance testing");
     STATIC_REQUIRE(constTestString.front() == 'T');
     STATIC_REQUIRE(constTestString.back() == 'g');
   }
@@ -1208,7 +1208,7 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
     REQUIRE(testString.back() == 'D');
 
     // Compile-time checks
-    constexpr const FixedString<16> constTestString("Hello World");
+    constexpr FixedString<16> constTestString("Hello World");
     STATIC_REQUIRE(constTestString.front() == 'H');
     STATIC_REQUIRE(constTestString.back() == 'd');
   }
@@ -1227,7 +1227,7 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
     REQUIRE(testString.back() == 'Y');
 
     // Compile-time checks
-    constexpr const FixedString<16> constTestString(" Hello ");
+    constexpr FixedString<16> constTestString(" Hello ");
     STATIC_REQUIRE(constTestString.front() == ' ');
     STATIC_REQUIRE(constTestString.back() == ' ');
   }
@@ -1251,9 +1251,9 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr operations") {
-    constexpr const FixedString<16> str1("Hello");
-    constexpr const FixedString<16> str2("World");
-    constexpr const FixedString<16> str3("Test");
+    constexpr FixedString<16> str1("Hello");
+    constexpr FixedString<16> str2("World");
+    constexpr FixedString<16> str3("Test");
 
     // Compile-time front operations
     STATIC_REQUIRE(str1.front() == 'H');
@@ -1269,9 +1269,9 @@ TEST_CASE("FixedString front and back", "[core][fixed_string]") {
 
 TEST_CASE("FixedString data", "[core][fixed_string]") {
   SECTION("Basic data access") {
-    constexpr const FixedString<16> testString("Hello World");
-    constexpr const FixedString<8> emptyString("");
-    constexpr const FixedString<4> singleChar("A");
+    constexpr FixedString<16> testString("Hello World");
+    constexpr FixedString<8> emptyString("");
+    constexpr FixedString<4> singleChar("A");
 
     // Test that data() points to null-terminated string
     REQUIRE(std::strcmp(testString.data(), "Hello World") == 0);
@@ -1285,9 +1285,9 @@ TEST_CASE("FixedString data", "[core][fixed_string]") {
   }
 
   SECTION("Data pointer stability") {
-    constexpr const FixedString<32> testString("Stability Test");
-    constexpr const FixedString<32> copy1(testString);
-    constexpr const FixedString<32> copy2(testString);
+    constexpr FixedString<32> testString("Stability Test");
+    constexpr FixedString<32> copy1(testString);
+    constexpr FixedString<32> copy2(testString);
 
     // Test that data() returns consistent pointers
     REQUIRE(testString.data() == testString.data());
@@ -1310,8 +1310,8 @@ TEST_CASE("FixedString data", "[core][fixed_string]") {
   }
 
   SECTION("Empty string") {
-    constexpr const FixedString<8> emptyString("");
-    constexpr const FixedString<16> defaultString;
+    constexpr FixedString<8> emptyString("");
+    constexpr FixedString<16> defaultString;
 
     // Test data() with empty strings
     REQUIRE(std::strcmp(emptyString.data(), "") == 0);
@@ -1325,9 +1325,9 @@ TEST_CASE("FixedString data", "[core][fixed_string]") {
 
 TEST_CASE("FixedString c_str method", "[core][fixed_string]") {
   SECTION("Basic c_str access") {
-    constexpr const FixedString<16> testString("Hello World");
-    constexpr const FixedString<8> emptyString("");
-    constexpr const FixedString<4> singleChar("A");
+    constexpr FixedString<16> testString("Hello World");
+    constexpr FixedString<8> emptyString("");
+    constexpr FixedString<4> singleChar("A");
 
     // Test that c_str() returns the same as data()
     REQUIRE(testString.c_str() == testString.data());
@@ -1350,9 +1350,9 @@ TEST_CASE("FixedString c_str method", "[core][fixed_string]") {
   }
 
   SECTION("C string pointer stability") {
-    constexpr const FixedString<32> testString("Stability Test");
-    constexpr const FixedString<32> copy1(testString);
-    constexpr const FixedString<32> copy2(testString);
+    constexpr FixedString<32> testString("Stability Test");
+    constexpr FixedString<32> copy1(testString);
+    constexpr FixedString<32> copy2(testString);
 
     // Test that c_str() returns consistent pointers
     REQUIRE(testString.c_str() == testString.c_str());
@@ -1375,8 +1375,8 @@ TEST_CASE("FixedString c_str method", "[core][fixed_string]") {
   }
 
   SECTION("Empty string") {
-    constexpr const FixedString<8> emptyString("");
-    constexpr const FixedString<16> defaultString;
+    constexpr FixedString<8> emptyString("");
+    constexpr FixedString<16> defaultString;
 
     // Test c_str() with empty strings
     REQUIRE(std::strcmp(emptyString.c_str(), "") == 0);
@@ -1390,9 +1390,9 @@ TEST_CASE("FixedString c_str method", "[core][fixed_string]") {
 
 TEST_CASE("FixedString empty method", "[core][fixed_string]") {
   SECTION("Basic empty check") {
-    constexpr const FixedString<16> nonEmptyString("Hello World");
-    constexpr const FixedString<8> emptyString("");
-    constexpr const FixedString<4> defaultString;
+    constexpr FixedString<16> nonEmptyString("Hello World");
+    constexpr FixedString<8> emptyString("");
+    constexpr FixedString<4> defaultString;
 
     REQUIRE_FALSE(nonEmptyString.empty());
     REQUIRE(emptyString.empty());
@@ -1405,8 +1405,8 @@ TEST_CASE("FixedString empty method", "[core][fixed_string]") {
   }
 
   SECTION("Single character strings") {
-    constexpr const FixedString<8> singleChar("A");
-    constexpr const FixedString<4> emptyString("");
+    constexpr FixedString<8> singleChar("A");
+    constexpr FixedString<4> emptyString("");
 
     REQUIRE_FALSE(singleChar.empty());
     REQUIRE(emptyString.empty());
@@ -1417,12 +1417,12 @@ TEST_CASE("FixedString empty method", "[core][fixed_string]") {
   }
 
   SECTION("Different capacities") {
-    constexpr const FixedString<8> smallString("Hi");
-    constexpr const FixedString<16> mediumString("Hello World");
-    constexpr const FixedString<32> largeString("This is a longer string");
-    constexpr const FixedString<8> emptySmall("");
-    constexpr const FixedString<16> emptyMedium("");
-    constexpr const FixedString<32> emptyLarge("");
+    constexpr FixedString<8> smallString("Hi");
+    constexpr FixedString<16> mediumString("Hello World");
+    constexpr FixedString<32> largeString("This is a longer string");
+    constexpr FixedString<8> emptySmall("");
+    constexpr FixedString<16> emptyMedium("");
+    constexpr FixedString<32> emptyLarge("");
 
     REQUIRE_FALSE(smallString.empty());
     REQUIRE_FALSE(mediumString.empty());
@@ -1441,10 +1441,10 @@ TEST_CASE("FixedString empty method", "[core][fixed_string]") {
   }
 
   SECTION("Special characters") {
-    constexpr const FixedString<32> newlineString("Hello\nWorld");
-    constexpr const FixedString<32> tabString("Hello\tWorld");
-    constexpr const FixedString<32> specialString("!@#$%^&*()");
-    constexpr const FixedString<32> emptyString("");
+    constexpr FixedString<32> newlineString("Hello\nWorld");
+    constexpr FixedString<32> tabString("Hello\tWorld");
+    constexpr FixedString<32> specialString("!@#$%^&*()");
+    constexpr FixedString<32> emptyString("");
 
     REQUIRE_FALSE(newlineString.empty());
     REQUIRE_FALSE(tabString.empty());
@@ -1459,10 +1459,10 @@ TEST_CASE("FixedString empty method", "[core][fixed_string]") {
   }
 
   SECTION("Unicode content") {
-    constexpr const FixedString<64> unicodeString("Привет мир");
-    constexpr const FixedString<64> emojiString("Hello 🌍 World");
-    constexpr const FixedString<64> mixedString("Hello 世界");
-    constexpr const FixedString<64> emptyString("");
+    constexpr FixedString<64> unicodeString("Привет мир");
+    constexpr FixedString<64> emojiString("Hello 🌍 World");
+    constexpr FixedString<64> mixedString("Hello 世界");
+    constexpr FixedString<64> emptyString("");
 
     REQUIRE_FALSE(unicodeString.empty());
     REQUIRE_FALSE(emojiString.empty());
@@ -1477,10 +1477,10 @@ TEST_CASE("FixedString empty method", "[core][fixed_string]") {
   }
 
   SECTION("Numeric content") {
-    constexpr const FixedString<16> numericString("12345");
-    constexpr const FixedString<16> floatString("3.14159");
-    constexpr const FixedString<16> hexString("0xABCD");
-    constexpr const FixedString<16> emptyString("");
+    constexpr FixedString<16> numericString("12345");
+    constexpr FixedString<16> floatString("3.14159");
+    constexpr FixedString<16> hexString("0xABCD");
+    constexpr FixedString<16> emptyString("");
 
     REQUIRE_FALSE(numericString.empty());
     REQUIRE_FALSE(floatString.empty());
@@ -1495,10 +1495,10 @@ TEST_CASE("FixedString empty method", "[core][fixed_string]") {
   }
 
   SECTION("Mixed content") {
-    constexpr const FixedString<32> mixedString("Hello123World!@#");
-    constexpr const FixedString<32> complexString("Test\n123\t!@#");
-    constexpr const FixedString<64> longString("This is a very long string with mixed content 123!@#");
-    constexpr const FixedString<32> emptyString("");
+    constexpr FixedString<32> mixedString("Hello123World!@#");
+    constexpr FixedString<32> complexString("Test\n123\t!@#");
+    constexpr FixedString<64> longString("This is a very long string with mixed content 123!@#");
+    constexpr FixedString<32> emptyString("");
 
     REQUIRE_FALSE(mixedString.empty());
     REQUIRE_FALSE(complexString.empty());
@@ -1513,10 +1513,10 @@ TEST_CASE("FixedString empty method", "[core][fixed_string]") {
   }
 
   SECTION("Maximum length strings") {
-    constexpr const FixedString<16> maxString("123456789012345"); // 15 characters
-    constexpr const FixedString<8> maxSmall("1234567"); // 7 characters
-    constexpr const FixedString<4> maxTiny("123"); // 3 characters
-    constexpr const FixedString<16> emptyString("");
+    constexpr FixedString<16> maxString("123456789012345"); // 15 characters
+    constexpr FixedString<8> maxSmall("1234567"); // 7 characters
+    constexpr FixedString<4> maxTiny("123"); // 3 characters
+    constexpr FixedString<16> emptyString("");
 
     REQUIRE_FALSE(maxString.empty());
     REQUIRE_FALSE(maxSmall.empty());
@@ -1531,10 +1531,10 @@ TEST_CASE("FixedString empty method", "[core][fixed_string]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const FixedString<8> singleChar("A");
-    constexpr const FixedString<8> twoChars("AB");
-    constexpr const FixedString<8> emptyString("");
-    constexpr const FixedString<8> defaultString;
+    constexpr FixedString<8> singleChar("A");
+    constexpr FixedString<8> twoChars("AB");
+    constexpr FixedString<8> emptyString("");
+    constexpr FixedString<8> defaultString;
 
     REQUIRE_FALSE(singleChar.empty());
     REQUIRE_FALSE(twoChars.empty());
@@ -1559,9 +1559,9 @@ TEST_CASE("FixedString empty method", "[core][fixed_string]") {
 
 TEST_CASE("FixedString size method", "[core][fixed_string]") {
   SECTION("Basic size check") {
-    constexpr const FixedString<16> testString("Hello World");
-    constexpr const FixedString<8> emptyString("");
-    constexpr const FixedString<4> defaultString;
+    constexpr FixedString<16> testString("Hello World");
+    constexpr FixedString<8> emptyString("");
+    constexpr FixedString<4> defaultString;
 
     REQUIRE(testString.size() == 11);
     REQUIRE(emptyString.size() == 0);
@@ -1574,8 +1574,8 @@ TEST_CASE("FixedString size method", "[core][fixed_string]") {
   }
 
   SECTION("Single character strings") {
-    constexpr const FixedString<8> singleChar("A");
-    constexpr const FixedString<4> emptyString("");
+    constexpr FixedString<8> singleChar("A");
+    constexpr FixedString<4> emptyString("");
 
     REQUIRE(singleChar.size() == 1);
     REQUIRE(emptyString.size() == 0);
@@ -1586,12 +1586,12 @@ TEST_CASE("FixedString size method", "[core][fixed_string]") {
   }
 
   SECTION("Different capacities") {
-    constexpr const FixedString<8> smallString("Hi");
-    constexpr const FixedString<16> mediumString("Hello World");
-    constexpr const FixedString<32> largeString("This is a longer string");
-    constexpr const FixedString<8> emptySmall("");
-    constexpr const FixedString<16> emptyMedium("");
-    constexpr const FixedString<32> emptyLarge("");
+    constexpr FixedString<8> smallString("Hi");
+    constexpr FixedString<16> mediumString("Hello World");
+    constexpr FixedString<32> largeString("This is a longer string");
+    constexpr FixedString<8> emptySmall("");
+    constexpr FixedString<16> emptyMedium("");
+    constexpr FixedString<32> emptyLarge("");
 
     REQUIRE(smallString.size() == 2);
     REQUIRE(mediumString.size() == 11);
@@ -1610,10 +1610,10 @@ TEST_CASE("FixedString size method", "[core][fixed_string]") {
   }
 
   SECTION("Special characters") {
-    constexpr const FixedString<32> newlineString("Hello\nWorld");
-    constexpr const FixedString<32> tabString("Hello\tWorld");
-    constexpr const FixedString<32> specialString("!@#$%^&*()");
-    constexpr const FixedString<32> emptyString("");
+    constexpr FixedString<32> newlineString("Hello\nWorld");
+    constexpr FixedString<32> tabString("Hello\tWorld");
+    constexpr FixedString<32> specialString("!@#$%^&*()");
+    constexpr FixedString<32> emptyString("");
 
     REQUIRE(newlineString.size() == 11);
     REQUIRE(tabString.size() == 11);
@@ -1628,10 +1628,10 @@ TEST_CASE("FixedString size method", "[core][fixed_string]") {
   }
 
   SECTION("Unicode content") {
-    constexpr const FixedString<64> unicodeString("Привет мир");
-    constexpr const FixedString<64> emojiString("Hello 🌍 World");
-    constexpr const FixedString<64> mixedString("Hello 世界");
-    constexpr const FixedString<64> emptyString("");
+    constexpr FixedString<64> unicodeString("Привет мир");
+    constexpr FixedString<64> emojiString("Hello 🌍 World");
+    constexpr FixedString<64> mixedString("Hello 世界");
+    constexpr FixedString<64> emptyString("");
 
     REQUIRE(unicodeString.size() == 19);
     REQUIRE(emojiString.size() == 16);
@@ -1646,10 +1646,10 @@ TEST_CASE("FixedString size method", "[core][fixed_string]") {
   }
 
   SECTION("Numeric content") {
-    constexpr const FixedString<16> numericString("12345");
-    constexpr const FixedString<16> floatString("3.14159");
-    constexpr const FixedString<16> hexString("0xABCD");
-    constexpr const FixedString<16> emptyString("");
+    constexpr FixedString<16> numericString("12345");
+    constexpr FixedString<16> floatString("3.14159");
+    constexpr FixedString<16> hexString("0xABCD");
+    constexpr FixedString<16> emptyString("");
 
     REQUIRE(numericString.size() == 5);
     REQUIRE(floatString.size() == 7);
@@ -1664,10 +1664,10 @@ TEST_CASE("FixedString size method", "[core][fixed_string]") {
   }
 
   SECTION("Mixed content") {
-    constexpr const FixedString<32> mixedString("Hello123World!@#");
-    constexpr const FixedString<32> complexString("Test\n123\t!@#");
-    constexpr const FixedString<64> longString("This is a very long string with mixed content 123!@#");
-    constexpr const FixedString<32> emptyString("");
+    constexpr FixedString<32> mixedString("Hello123World!@#");
+    constexpr FixedString<32> complexString("Test\n123\t!@#");
+    constexpr FixedString<64> longString("This is a very long string with mixed content 123!@#");
+    constexpr FixedString<32> emptyString("");
 
     REQUIRE(mixedString.size() == 16);
     REQUIRE(complexString.size() == 12);
@@ -1682,10 +1682,10 @@ TEST_CASE("FixedString size method", "[core][fixed_string]") {
   }
 
   SECTION("Maximum length strings") {
-    constexpr const FixedString<16> maxString("123456789012345"); // 15 characters
-    constexpr const FixedString<8> maxSmall("1234567"); // 7 characters
-    constexpr const FixedString<4> maxTiny("123"); // 3 characters
-    constexpr const FixedString<16> emptyString("");
+    constexpr FixedString<16> maxString("123456789012345"); // 15 characters
+    constexpr FixedString<8> maxSmall("1234567"); // 7 characters
+    constexpr FixedString<4> maxTiny("123"); // 3 characters
+    constexpr FixedString<16> emptyString("");
 
     REQUIRE(maxString.size() == 15);
     REQUIRE(maxSmall.size() == 7);
@@ -1700,10 +1700,10 @@ TEST_CASE("FixedString size method", "[core][fixed_string]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const FixedString<8> singleChar("A");
-    constexpr const FixedString<8> twoChars("AB");
-    constexpr const FixedString<8> emptyString("");
-    constexpr const FixedString<8> defaultString;
+    constexpr FixedString<8> singleChar("A");
+    constexpr FixedString<8> twoChars("AB");
+    constexpr FixedString<8> emptyString("");
+    constexpr FixedString<8> defaultString;
 
     REQUIRE(singleChar.size() == 1);
     REQUIRE(twoChars.size() == 2);
@@ -1720,9 +1720,9 @@ TEST_CASE("FixedString size method", "[core][fixed_string]") {
 
 TEST_CASE("FixedString utf8_size", "[core][fixed_string]") {
   SECTION("ASCII strings") {
-    constexpr const FixedString<32> asciiString("Hello World");
-    constexpr const FixedString<16> emptyString("");
-    constexpr const FixedString<8> singleChar("A");
+    constexpr FixedString<32> asciiString("Hello World");
+    constexpr FixedString<16> emptyString("");
+    constexpr FixedString<8> singleChar("A");
 
     REQUIRE(asciiString.utf8_size() == 11);
     REQUIRE(emptyString.utf8_size() == 0);
@@ -1741,7 +1741,7 @@ TEST_CASE("FixedString utf8_size", "[core][fixed_string]") {
                                                         char(0xD1), char(0x82), char(0x20), char(0xD0), char(0xBC),
                                                         char(0xD0), char(0xB8), char(0xD1), char(0x80), char(0x00)}};
 
-    constexpr const FixedString<32> cyrillicString(cyrillicText.data());
+    constexpr FixedString<32> cyrillicString(cyrillicText.data());
 
     REQUIRE(cyrillicString.size() == 19);
     REQUIRE(cyrillicString.utf8_size() == 10);
@@ -1753,7 +1753,7 @@ TEST_CASE("FixedString utf8_size", "[core][fixed_string]") {
                                                      char(0x20), char(0xE4), char(0xB8), char(0x96), char(0xE7),
                                                      char(0x95), char(0x8C), char(0x00)}};
 
-    constexpr const FixedString<16> mixedString(mixedText.data());
+    constexpr FixedString<16> mixedString(mixedText.data());
 
     REQUIRE(mixedString.size() == 12);
     REQUIRE(mixedString.utf8_size() == 8); // 6 ASCII + 2 Chinese characters
@@ -1765,16 +1765,16 @@ TEST_CASE("FixedString utf8_size", "[core][fixed_string]") {
                                                      char(0x20), char(0xF0), char(0x9F), char(0x8C), char(0x8D),
                                                      char(0x00)}};
 
-    constexpr const FixedString<16> emojiString(emojiText.data());
+    constexpr FixedString<16> emojiString(emojiText.data());
 
     REQUIRE(emojiString.size() == 10);
     REQUIRE(emojiString.utf8_size() == 7); // 6 ASCII + 1 emoji
   }
 
   SECTION("Special characters") {
-    constexpr const FixedString<32> specialString("!@#$%^&*()");
-    constexpr const FixedString<16> numericString("1234567890");
-    constexpr const FixedString<8> punctuationString(".,;:!?");
+    constexpr FixedString<32> specialString("!@#$%^&*()");
+    constexpr FixedString<16> numericString("1234567890");
+    constexpr FixedString<8> punctuationString(".,;:!?");
 
     REQUIRE(specialString.utf8_size() == 10);
     REQUIRE(numericString.utf8_size() == 10);
@@ -1787,10 +1787,10 @@ TEST_CASE("FixedString utf8_size", "[core][fixed_string]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const FixedString<8> singleByte("A");
-    constexpr const FixedString<16> twoByte("А"); // Cyrillic A
-    constexpr const FixedString<16> threeByte("中"); // Chinese character
-    constexpr const FixedString<16> fourByte("🌍"); // Emoji
+    constexpr FixedString<8> singleByte("A");
+    constexpr FixedString<16> twoByte("А"); // Cyrillic A
+    constexpr FixedString<16> threeByte("中"); // Chinese character
+    constexpr FixedString<16> fourByte("🌍"); // Emoji
 
     REQUIRE(singleByte.utf8_size() == 1);
     REQUIRE(twoByte.utf8_size() == 1);
@@ -1810,7 +1810,7 @@ TEST_CASE("FixedString utf8_size", "[core][fixed_string]") {
        char(0xB4), char(0xD0), char(0xB2), char(0xD0), char(0xB8), char(0xD0), char(0xB6), char(0xD0), char(0xBE),
        char(0xD0), char(0xBA), char(0x2E), char(0x00)}};
 
-    constexpr const FixedString<80> longString(longUtf8Text.data());
+    constexpr FixedString<80> longString(longUtf8Text.data());
 
     REQUIRE(longString.size() == 66); // 66 bytes
     REQUIRE(longString.utf8_size() == 43); // 43 characters
@@ -1819,9 +1819,9 @@ TEST_CASE("FixedString utf8_size", "[core][fixed_string]") {
 
 TEST_CASE("FixedString length", "[core][fixed_string]") {
   SECTION("Basic length check") {
-    constexpr const FixedString<32> testString("Hello World");
-    constexpr const FixedString<16> emptyString("");
-    constexpr const FixedString<8> singleChar("A");
+    constexpr FixedString<32> testString("Hello World");
+    constexpr FixedString<16> emptyString("");
+    constexpr FixedString<8> singleChar("A");
 
     REQUIRE(testString.length() == 11);
     REQUIRE(emptyString.length() == 0);
@@ -1838,12 +1838,12 @@ TEST_CASE("FixedString length", "[core][fixed_string]") {
   }
 
   SECTION("Different capacities") {
-    constexpr const FixedString<8> smallString("Hi");
-    constexpr const FixedString<16> mediumString("Hello World");
-    constexpr const FixedString<32> largeString("This is a longer string");
-    constexpr const FixedString<8> emptySmall("");
-    constexpr const FixedString<16> emptyMedium("");
-    constexpr const FixedString<32> emptyLarge("");
+    constexpr FixedString<8> smallString("Hi");
+    constexpr FixedString<16> mediumString("Hello World");
+    constexpr FixedString<32> largeString("This is a longer string");
+    constexpr FixedString<8> emptySmall("");
+    constexpr FixedString<16> emptyMedium("");
+    constexpr FixedString<32> emptyLarge("");
 
     REQUIRE(smallString.length() == 2);
     REQUIRE(mediumString.length() == 11);
@@ -1866,10 +1866,10 @@ TEST_CASE("FixedString length", "[core][fixed_string]") {
   }
 
   SECTION("Special characters") {
-    constexpr const FixedString<32> newlineString("Hello\nWorld");
-    constexpr const FixedString<32> tabString("Hello\tWorld");
-    constexpr const FixedString<32> specialString("!@#$%^&*()");
-    constexpr const FixedString<32> emptyString("");
+    constexpr FixedString<32> newlineString("Hello\nWorld");
+    constexpr FixedString<32> tabString("Hello\tWorld");
+    constexpr FixedString<32> specialString("!@#$%^&*()");
+    constexpr FixedString<32> emptyString("");
 
     REQUIRE(newlineString.length() == 11);
     REQUIRE(tabString.length() == 11);
@@ -1888,10 +1888,10 @@ TEST_CASE("FixedString length", "[core][fixed_string]") {
   }
 
   SECTION("Unicode content") {
-    constexpr const FixedString<64> unicodeString("Привет мир");
-    constexpr const FixedString<64> emojiString("Hello 🌍 World");
-    constexpr const FixedString<64> mixedString("Hello 世界");
-    constexpr const FixedString<64> emptyString("");
+    constexpr FixedString<64> unicodeString("Привет мир");
+    constexpr FixedString<64> emojiString("Hello 🌍 World");
+    constexpr FixedString<64> mixedString("Hello 世界");
+    constexpr FixedString<64> emptyString("");
 
     REQUIRE(unicodeString.length() == 19);
     REQUIRE(emojiString.length() == 16);
@@ -1910,10 +1910,10 @@ TEST_CASE("FixedString length", "[core][fixed_string]") {
   }
 
   SECTION("Numeric content") {
-    constexpr const FixedString<32> numericString("12345");
-    constexpr const FixedString<32> floatString("3.14159");
-    constexpr const FixedString<32> hexString("0xABCD");
-    constexpr const FixedString<32> emptyString("");
+    constexpr FixedString<32> numericString("12345");
+    constexpr FixedString<32> floatString("3.14159");
+    constexpr FixedString<32> hexString("0xABCD");
+    constexpr FixedString<32> emptyString("");
 
     REQUIRE(numericString.length() == 5);
     REQUIRE(floatString.length() == 7);
@@ -1932,10 +1932,10 @@ TEST_CASE("FixedString length", "[core][fixed_string]") {
   }
 
   SECTION("Mixed content") {
-    constexpr const FixedString<64> mixedString("Hello123World!@#");
-    constexpr const FixedString<64> complexString("Test\n123\t!@#");
-    constexpr const FixedString<64> longString("This is a very long string with mixed content 123!@#");
-    constexpr const FixedString<64> emptyString("");
+    constexpr FixedString<64> mixedString("Hello123World!@#");
+    constexpr FixedString<64> complexString("Test\n123\t!@#");
+    constexpr FixedString<64> longString("This is a very long string with mixed content 123!@#");
+    constexpr FixedString<64> emptyString("");
 
     REQUIRE(mixedString.length() == 16);
     REQUIRE(complexString.length() == 12);
@@ -1954,10 +1954,10 @@ TEST_CASE("FixedString length", "[core][fixed_string]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const FixedString<8> singleChar("A");
-    constexpr const FixedString<8> twoChars("AB");
-    constexpr const FixedString<8> emptyString("");
-    constexpr const FixedString<8> defaultString;
+    constexpr FixedString<8> singleChar("A");
+    constexpr FixedString<8> twoChars("AB");
+    constexpr FixedString<8> emptyString("");
+    constexpr FixedString<8> defaultString;
 
     REQUIRE(singleChar.length() == 1);
     REQUIRE(twoChars.length() == 2);
@@ -1979,10 +1979,10 @@ TEST_CASE("FixedString length", "[core][fixed_string]") {
 
 TEST_CASE("FixedString max_size", "[core][fixed_string]") {
   SECTION("Basic max_size check") {
-    constexpr const FixedString<8> smallString("Hi");
-    constexpr const FixedString<16> mediumString("Hello World");
-    constexpr const FixedString<32> largeString("This is a longer string");
-    constexpr const FixedString<64> extraLargeString("This is an even longer string for testing");
+    constexpr FixedString<8> smallString("Hi");
+    constexpr FixedString<16> mediumString("Hello World");
+    constexpr FixedString<32> largeString("This is a longer string");
+    constexpr FixedString<64> extraLargeString("This is an even longer string for testing");
 
     REQUIRE(smallString.max_size() == 7);
     REQUIRE(mediumString.max_size() == 15);
@@ -1996,10 +1996,10 @@ TEST_CASE("FixedString max_size", "[core][fixed_string]") {
   }
 
   SECTION("Empty strings") {
-    constexpr const FixedString<8> emptySmall("");
-    constexpr const FixedString<16> emptyMedium("");
-    constexpr const FixedString<32> emptyLarge("");
-    constexpr const FixedString<64> emptyExtraLarge("");
+    constexpr FixedString<8> emptySmall("");
+    constexpr FixedString<16> emptyMedium("");
+    constexpr FixedString<32> emptyLarge("");
+    constexpr FixedString<64> emptyExtraLarge("");
 
     REQUIRE(emptySmall.max_size() == 7);
     REQUIRE(emptyMedium.max_size() == 15);
@@ -2013,10 +2013,10 @@ TEST_CASE("FixedString max_size", "[core][fixed_string]") {
   }
 
   SECTION("Default constructed strings") {
-    constexpr const FixedString<8> defaultSmall;
-    constexpr const FixedString<16> defaultMedium;
-    constexpr const FixedString<32> defaultLarge;
-    constexpr const FixedString<64> defaultExtraLarge;
+    constexpr FixedString<8> defaultSmall;
+    constexpr FixedString<16> defaultMedium;
+    constexpr FixedString<32> defaultLarge;
+    constexpr FixedString<64> defaultExtraLarge;
 
     REQUIRE(defaultSmall.max_size() == 7);
     REQUIRE(defaultMedium.max_size() == 15);
@@ -2030,10 +2030,10 @@ TEST_CASE("FixedString max_size", "[core][fixed_string]") {
   }
 
   SECTION("Single character strings") {
-    constexpr const FixedString<8> singleSmall("A");
-    constexpr const FixedString<16> singleMedium("B");
-    constexpr const FixedString<32> singleLarge("C");
-    constexpr const FixedString<64> singleExtraLarge("D");
+    constexpr FixedString<8> singleSmall("A");
+    constexpr FixedString<16> singleMedium("B");
+    constexpr FixedString<32> singleLarge("C");
+    constexpr FixedString<64> singleExtraLarge("D");
 
     REQUIRE(singleSmall.max_size() == 7);
     REQUIRE(singleMedium.max_size() == 15);
@@ -2047,10 +2047,10 @@ TEST_CASE("FixedString max_size", "[core][fixed_string]") {
   }
 
   SECTION("Maximum length strings") {
-    constexpr const FixedString<8> maxSmall("1234567"); // 7 characters (max for capacity 8)
-    constexpr const FixedString<16> maxMedium("123456789012345"); // 15 characters (max for capacity 16)
-    constexpr const FixedString<32> maxLarge("1234567890123456789012345678901"); // 31 characters (max for capacity 32)
-    constexpr const FixedString<64> maxExtraLarge(
+    constexpr FixedString<8> maxSmall("1234567"); // 7 characters (max for capacity 8)
+    constexpr FixedString<16> maxMedium("123456789012345"); // 15 characters (max for capacity 16)
+    constexpr FixedString<32> maxLarge("1234567890123456789012345678901"); // 31 characters (max for capacity 32)
+    constexpr FixedString<64> maxExtraLarge(
       "123456789012345678901234567890123456789012345678901234567890123"); // 63 characters (max for capacity 64)
 
     REQUIRE(maxSmall.max_size() == 7);
@@ -2065,12 +2065,12 @@ TEST_CASE("FixedString max_size", "[core][fixed_string]") {
   }
 
   SECTION("Different template parameters") {
-    constexpr const FixedString<4> tinyString("Hi");
-    constexpr const FixedString<8> smallString("Hello");
-    constexpr const FixedString<16> mediumString("Hello World");
-    constexpr const FixedString<32> largeString("This is a longer string");
-    constexpr const FixedString<64> extraLargeString("This is an even longer string for testing");
-    constexpr const FixedString<128> hugeString(
+    constexpr FixedString<4> tinyString("Hi");
+    constexpr FixedString<8> smallString("Hello");
+    constexpr FixedString<16> mediumString("Hello World");
+    constexpr FixedString<32> largeString("This is a longer string");
+    constexpr FixedString<64> extraLargeString("This is an even longer string for testing");
+    constexpr FixedString<128> hugeString(
       "This is a very long string that tests the maximum capacity of a large FixedString buffer");
 
     REQUIRE(tinyString.max_size() == 3);
@@ -2089,9 +2089,9 @@ TEST_CASE("FixedString max_size", "[core][fixed_string]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const FixedString<1> minimalString; // Should have max_size() == 0
-    constexpr const FixedString<2> twoCharString("A");
-    constexpr const FixedString<3> threeCharString("AB");
+    constexpr FixedString<1> minimalString; // Should have max_size() == 0
+    constexpr FixedString<2> twoCharString("A");
+    constexpr FixedString<3> threeCharString("AB");
 
     REQUIRE(minimalString.max_size() == 0);
     REQUIRE(twoCharString.max_size() == 1);
@@ -2103,9 +2103,9 @@ TEST_CASE("FixedString max_size", "[core][fixed_string]") {
   }
 
   SECTION("Consistency with capacity") {
-    constexpr const FixedString<8> testString1("Hello");
-    constexpr const FixedString<16> testString2("World");
-    constexpr const FixedString<32> testString3("Test");
+    constexpr FixedString<8> testString1("Hello");
+    constexpr FixedString<16> testString2("World");
+    constexpr FixedString<32> testString3("Test");
 
     // max_size() should equal capacity() for all FixedString instances
     REQUIRE(testString1.max_size() == testString1.capacity());
@@ -2120,10 +2120,10 @@ TEST_CASE("FixedString max_size", "[core][fixed_string]") {
 
 TEST_CASE("FixedString capacity", "[core][fixed_string]") {
   SECTION("Basic capacity check") {
-    constexpr const FixedString<8> smallString("Hi");
-    constexpr const FixedString<16> mediumString("Hello World");
-    constexpr const FixedString<32> largeString("This is a longer string");
-    constexpr const FixedString<64> extraLargeString("This is an even longer string for testing");
+    constexpr FixedString<8> smallString("Hi");
+    constexpr FixedString<16> mediumString("Hello World");
+    constexpr FixedString<32> largeString("This is a longer string");
+    constexpr FixedString<64> extraLargeString("This is an even longer string for testing");
 
     REQUIRE(smallString.capacity() == 7);
     REQUIRE(mediumString.capacity() == 15);
@@ -2137,10 +2137,10 @@ TEST_CASE("FixedString capacity", "[core][fixed_string]") {
   }
 
   SECTION("Empty strings") {
-    constexpr const FixedString<8> emptySmall("");
-    constexpr const FixedString<16> emptyMedium("");
-    constexpr const FixedString<32> emptyLarge("");
-    constexpr const FixedString<64> emptyExtraLarge("");
+    constexpr FixedString<8> emptySmall("");
+    constexpr FixedString<16> emptyMedium("");
+    constexpr FixedString<32> emptyLarge("");
+    constexpr FixedString<64> emptyExtraLarge("");
 
     REQUIRE(emptySmall.capacity() == 7);
     REQUIRE(emptyMedium.capacity() == 15);
@@ -2154,10 +2154,10 @@ TEST_CASE("FixedString capacity", "[core][fixed_string]") {
   }
 
   SECTION("Default constructed strings") {
-    constexpr const FixedString<8> defaultSmall;
-    constexpr const FixedString<16> defaultMedium;
-    constexpr const FixedString<32> defaultLarge;
-    constexpr const FixedString<64> defaultExtraLarge;
+    constexpr FixedString<8> defaultSmall;
+    constexpr FixedString<16> defaultMedium;
+    constexpr FixedString<32> defaultLarge;
+    constexpr FixedString<64> defaultExtraLarge;
 
     REQUIRE(defaultSmall.capacity() == 7);
     REQUIRE(defaultMedium.capacity() == 15);
@@ -2171,10 +2171,10 @@ TEST_CASE("FixedString capacity", "[core][fixed_string]") {
   }
 
   SECTION("Single character strings") {
-    constexpr const FixedString<8> singleSmall("A");
-    constexpr const FixedString<16> singleMedium("B");
-    constexpr const FixedString<32> singleLarge("C");
-    constexpr const FixedString<64> singleExtraLarge("D");
+    constexpr FixedString<8> singleSmall("A");
+    constexpr FixedString<16> singleMedium("B");
+    constexpr FixedString<32> singleLarge("C");
+    constexpr FixedString<64> singleExtraLarge("D");
 
     REQUIRE(singleSmall.capacity() == 7);
     REQUIRE(singleMedium.capacity() == 15);
@@ -2188,10 +2188,10 @@ TEST_CASE("FixedString capacity", "[core][fixed_string]") {
   }
 
   SECTION("Maximum length strings") {
-    constexpr const FixedString<8> maxSmall("1234567"); // 7 characters (max for capacity 8)
-    constexpr const FixedString<16> maxMedium("123456789012345"); // 15 characters (max for capacity 16)
-    constexpr const FixedString<32> maxLarge("1234567890123456789012345678901"); // 31 characters (max for capacity 32)
-    constexpr const FixedString<64> maxExtraLarge(
+    constexpr FixedString<8> maxSmall("1234567"); // 7 characters (max for capacity 8)
+    constexpr FixedString<16> maxMedium("123456789012345"); // 15 characters (max for capacity 16)
+    constexpr FixedString<32> maxLarge("1234567890123456789012345678901"); // 31 characters (max for capacity 32)
+    constexpr FixedString<64> maxExtraLarge(
       "123456789012345678901234567890123456789012345678901234567890123"); // 63 characters (max for capacity 64)
 
     REQUIRE(maxSmall.capacity() == 7);
@@ -2206,12 +2206,12 @@ TEST_CASE("FixedString capacity", "[core][fixed_string]") {
   }
 
   SECTION("Different template parameters") {
-    constexpr const FixedString<4> tinyString("Hi");
-    constexpr const FixedString<8> smallString("Hello");
-    constexpr const FixedString<16> mediumString("Hello World");
-    constexpr const FixedString<32> largeString("This is a longer string");
-    constexpr const FixedString<64> extraLargeString("This is an even longer string for testing");
-    constexpr const FixedString<128> hugeString(
+    constexpr FixedString<4> tinyString("Hi");
+    constexpr FixedString<8> smallString("Hello");
+    constexpr FixedString<16> mediumString("Hello World");
+    constexpr FixedString<32> largeString("This is a longer string");
+    constexpr FixedString<64> extraLargeString("This is an even longer string for testing");
+    constexpr FixedString<128> hugeString(
       "This is a very long string that tests the maximum capacity of a large FixedString buffer");
 
     REQUIRE(tinyString.capacity() == 3);
@@ -2230,9 +2230,9 @@ TEST_CASE("FixedString capacity", "[core][fixed_string]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const FixedString<1> minimalString; // Should have capacity() == 0
-    constexpr const FixedString<2> twoCharString("A");
-    constexpr const FixedString<3> threeCharString("AB");
+    constexpr FixedString<1> minimalString; // Should have capacity() == 0
+    constexpr FixedString<2> twoCharString("A");
+    constexpr FixedString<3> threeCharString("AB");
 
     REQUIRE(minimalString.capacity() == 0);
     REQUIRE(twoCharString.capacity() == 1);
@@ -2244,9 +2244,9 @@ TEST_CASE("FixedString capacity", "[core][fixed_string]") {
   }
 
   SECTION("Consistency with max_size") {
-    constexpr const FixedString<8> testString1("Hello");
-    constexpr const FixedString<16> testString2("World");
-    constexpr const FixedString<32> testString3("Test");
+    constexpr FixedString<8> testString1("Hello");
+    constexpr FixedString<16> testString2("World");
+    constexpr FixedString<32> testString3("Test");
 
     // capacity() should equal max_size() for all FixedString instances
     REQUIRE(testString1.capacity() == testString1.max_size());
@@ -2260,11 +2260,11 @@ TEST_CASE("FixedString capacity", "[core][fixed_string]") {
 
   SECTION("Capacity formula validation") {
     // Test the formula: capacity = N - 1 (where N is the template parameter)
-    constexpr const FixedString<4> test4("Hi");
-    constexpr const FixedString<8> test8("Hello");
-    constexpr const FixedString<16> test16("Hello World");
-    constexpr const FixedString<32> test32("This is a longer string");
-    constexpr const FixedString<64> test64("This is an even longer string for testing");
+    constexpr FixedString<4> test4("Hi");
+    constexpr FixedString<8> test8("Hello");
+    constexpr FixedString<16> test16("Hello World");
+    constexpr FixedString<32> test32("This is a longer string");
+    constexpr FixedString<64> test64("This is an even longer string for testing");
 
     REQUIRE(test4.capacity() == 3); // 4 - 1 = 3
     REQUIRE(test8.capacity() == 7); // 8 - 1 = 7
@@ -4275,126 +4275,171 @@ TEST_CASE("FixedString replace", "[core][fixed_string]") {
   }
 }
 
-// to refactor 5879 - 4278 = 1601
-
 TEST_CASE("FixedString copy", "[core][fixed_string]") {
   SECTION("Copy entire string") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, 11) == 11);
     REQUIRE(strncmp(buffer, "Hello World", 11) == 0);
   }
 
   SECTION("Copy partial string from beginning") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, 5) == 5);
     REQUIRE(strncmp(buffer, "Hello", 5) == 0);
   }
 
   SECTION("Copy partial string from middle") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, 5, 6) == 5);
     REQUIRE(strncmp(buffer, "World", 5) == 0);
   }
 
   SECTION("Copy with npos count") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, FixedString<16>::npos) == 11);
     REQUIRE(strncmp(buffer, "Hello World", 11) == 0);
   }
 
   SECTION("Copy with count exceeding remaining characters") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, 20, 6) == 5);
     REQUIRE(strncmp(buffer, "World", 5) == 0);
   }
 
   SECTION("Copy from position 0") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, 5, 0) == 5);
     REQUIRE(strncmp(buffer, "Hello", 5) == 0);
   }
 
   SECTION("Copy single character") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, 1, 6) == 1);
     REQUIRE(buffer[0] == 'W');
   }
 
   SECTION("Copy from end position") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, 1, 10) == 1);
     REQUIRE(buffer[0] == 'd');
   }
 
   SECTION("Copy with zero count") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, 0) == 0);
   }
 
   SECTION("Copy from empty string") {
-    constexpr const FixedString<16> testString("");
+    constexpr FixedString<16> testString("");
     char buffer[16] = {0};
+
+    REQUIRE(testString.empty());
+    REQUIRE(testString.size() == 0);
 
     REQUIRE(testString.copy(buffer, 5) == 0);
   }
 
   SECTION("Copy to small buffer") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[3] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, 2) == 2);
     REQUIRE(strncmp(buffer, "He", 2) == 0);
   }
 
   SECTION("Copy with position at end") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, 5, 11) == 0);
   }
 
   SECTION("Copy with npos from middle") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, FixedString<16>::npos, 6) == 5);
     REQUIRE(strncmp(buffer, "World", 5) == 0);
   }
 
   SECTION("Copy with exact remaining characters") {
-    constexpr const FixedString<16> testString("Hello World");
+    constexpr FixedString<16> testString("Hello World");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
 
     REQUIRE(testString.copy(buffer, 5, 6) == 5);
     REQUIRE(strncmp(buffer, "World", 5) == 0);
   }
 
   SECTION("Copy with count larger than string size") {
-    constexpr const FixedString<16> testString("Hi");
+    constexpr FixedString<16> testString("Hi");
     char buffer[16] = {0};
+
+    REQUIRE(testString.size() == 2);
+    REQUIRE(std::strcmp(testString.c_str(), "Hi") == 0);
 
     REQUIRE(testString.copy(buffer, 10) == 2);
     REQUIRE(strncmp(buffer, "Hi", 2) == 0);
   }
 }
+
+// to refactor 5924 - 4442 = 1482
 
 TEST_CASE("FixedString swap", "[core][fixed_string]") {
   SECTION("Swap two different strings") {
@@ -4510,7 +4555,7 @@ TEST_CASE("FixedString swap", "[core][fixed_string]") {
 
 TEST_CASE("FixedString find", "[core][fixed_string]") {
   SECTION("Find FixedString substring") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find(FixedString<16>("World")) == 6);
     REQUIRE(testString.find(FixedString<16>("Hello")) == 0);
@@ -4519,7 +4564,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find StringLike substring") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find(std::string("World")) == 6);
     REQUIRE(testString.find(std::string("Hello")) == 0);
@@ -4528,7 +4573,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find C string substring") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find("World") == 6);
     REQUIRE(testString.find("Hello") == 0);
@@ -4537,7 +4582,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find character") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find('H') == 0);
     REQUIRE(testString.find('l') == 2);
@@ -4548,7 +4593,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find with position parameter") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.find("Hello", 0) == 0);
     REQUIRE(testString.find("Hello", 1) == 12);
@@ -4560,7 +4605,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find empty substring") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find(FixedString<16>("")) == 0);
     REQUIRE(testString.find(std::string("")) == 0);
@@ -4570,7 +4615,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find in empty string") {
-    constexpr const FixedString<32> testString("");
+    constexpr FixedString<32> testString("");
 
     REQUIRE(testString.find(FixedString<16>("Hello")) == FixedString<32>::npos);
     REQUIRE(testString.find(std::string("Hello")) == FixedString<32>::npos);
@@ -4580,7 +4625,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find with position beyond string size") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.find("World", 10) == FixedString<32>::npos);
     REQUIRE(testString.find('H', 10) == FixedString<32>::npos);
@@ -4588,7 +4633,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find substring at end") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find("World") == 6);
     REQUIRE(testString.find("d") == 10);
@@ -4596,7 +4641,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find substring at beginning") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find("Hello") == 0);
     REQUIRE(testString.find("H") == 0);
@@ -4604,7 +4649,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find overlapping substrings") {
-    constexpr const FixedString<32> testString("ababab");
+    constexpr FixedString<32> testString("ababab");
 
     REQUIRE(testString.find("ab") == 0);
     REQUIRE(testString.find("ab", 1) == 2);
@@ -4613,7 +4658,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find with repeated characters") {
-    constexpr const FixedString<32> testString("aaaaa");
+    constexpr FixedString<32> testString("aaaaa");
 
     REQUIRE(testString.find("aa") == 0);
     REQUIRE(testString.find("aa", 1) == 1);
@@ -4623,7 +4668,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find case sensitivity") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find("hello") == FixedString<32>::npos);
     REQUIRE(testString.find("WORLD") == FixedString<32>::npos);
@@ -4632,7 +4677,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find with different FixedString capacities") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find(FixedString<8>("World")) == 6);
     REQUIRE(testString.find(FixedString<16>("World")) == 6);
@@ -4640,7 +4685,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find with exact match") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.find("Hello") == 0);
     REQUIRE(testString.find("Hello", 0) == 0);
@@ -4648,7 +4693,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
   }
 
   SECTION("Find with single character string") {
-    constexpr const FixedString<32> testString("A");
+    constexpr FixedString<32> testString("A");
 
     REQUIRE(testString.find("A") == 0);
     REQUIRE(testString.find('A') == 0);
@@ -4659,7 +4704,7 @@ TEST_CASE("FixedString find", "[core][fixed_string]") {
 
 TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   SECTION("Rfind FixedString substring") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.rfind(FixedString<16>("Hello")) == 12);
     REQUIRE(testString.rfind(FixedString<16>("World")) == 6);
@@ -4668,7 +4713,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind StringLike substring") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.rfind(std::string("Hello")) == 12);
     REQUIRE(testString.rfind(std::string("World")) == 6);
@@ -4677,7 +4722,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind C string substring") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.rfind("Hello") == 12);
     REQUIRE(testString.rfind("World") == 6);
@@ -4686,7 +4731,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind character") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.rfind('H') == 12);
     REQUIRE(testString.rfind('l') == 15);
@@ -4697,7 +4742,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind with position parameter") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.rfind("Hello", 12) == 12);
     REQUIRE(testString.rfind("Hello", 11) == 0);
@@ -4709,7 +4754,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind empty substring") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.rfind(FixedString<16>("")) == 11);
     REQUIRE(testString.rfind(std::string("")) == 11);
@@ -4719,7 +4764,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind in empty string") {
-    constexpr const FixedString<32> testString("");
+    constexpr FixedString<32> testString("");
 
     REQUIRE(testString.rfind(FixedString<16>("Hello")) == FixedString<32>::npos);
     REQUIRE(testString.rfind(std::string("Hello")) == FixedString<32>::npos);
@@ -4729,7 +4774,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind substring at end") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.rfind("World") == 6);
     REQUIRE(testString.rfind("d") == 10);
@@ -4737,7 +4782,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind substring at beginning") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.rfind("Hello") == 12);
     REQUIRE(testString.rfind("H") == 12);
@@ -4745,7 +4790,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind overlapping substrings") {
-    constexpr const FixedString<32> testString("ababab");
+    constexpr FixedString<32> testString("ababab");
 
     REQUIRE(testString.rfind("ab") == 4);
     REQUIRE(testString.rfind("ab", 3) == 2);
@@ -4754,7 +4799,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind with repeated characters") {
-    constexpr const FixedString<32> testString("aaaaa");
+    constexpr FixedString<32> testString("aaaaa");
 
     REQUIRE(testString.rfind("aa") == 3);
     REQUIRE(testString.rfind("aa", 2) == 2);
@@ -4763,7 +4808,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind case sensitivity") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.rfind("hello") == FixedString<32>::npos);
     REQUIRE(testString.rfind("WORLD") == FixedString<32>::npos);
@@ -4772,7 +4817,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind with different FixedString capacities") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.rfind(FixedString<8>("Hello")) == 12);
     REQUIRE(testString.rfind(FixedString<16>("Hello")) == 12);
@@ -4780,14 +4825,14 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind with exact match") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.rfind("Hello") == 0);
     REQUIRE(testString.rfind("Hello", 0) == 0);
   }
 
   SECTION("Rfind with single character string") {
-    constexpr const FixedString<32> testString("A");
+    constexpr FixedString<32> testString("A");
 
     REQUIRE(testString.rfind("A") == 0);
     REQUIRE(testString.rfind('A') == 0);
@@ -4796,7 +4841,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind with position 0") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.rfind("Hello", 0) == 0);
     REQUIRE(testString.rfind("World", 0) == FixedString<32>::npos);
@@ -4805,14 +4850,14 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind with substring longer than string") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.rfind("Hello World") == FixedString<32>::npos);
     REQUIRE(testString.rfind("Hello World", 10) == FixedString<32>::npos);
   }
 
   SECTION("Rfind with multiple occurrences") {
-    constexpr const FixedString<32> testString("abababab");
+    constexpr FixedString<32> testString("abababab");
 
     REQUIRE(testString.rfind("ab") == 6);
     REQUIRE(testString.rfind("ab", 5) == 4);
@@ -4821,7 +4866,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
   }
 
   SECTION("Rfind with position in middle") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.rfind("Hello", 8) == 0);
     REQUIRE(testString.rfind("Hello", 12) == 12);
@@ -4832,7 +4877,7 @@ TEST_CASE("FixedString rfind", "[core][fixed_string]") {
 
 TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   SECTION("Find first of FixedString characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_of(FixedString<16>("aeiou")) == 1); // 'e' at position 1
     REQUIRE(testString.find_first_of(FixedString<16>("H")) == 0);
@@ -4841,7 +4886,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of StringLike characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_of(std::string("aeiou")) == 1);
     REQUIRE(testString.find_first_of(std::string("H")) == 0);
@@ -4850,7 +4895,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of C string characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_of("aeiou") == 1);
     REQUIRE(testString.find_first_of("H") == 0);
@@ -4859,7 +4904,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of single character") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_of('H') == 0);
     REQUIRE(testString.find_first_of('e') == 1);
@@ -4871,7 +4916,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of with position parameter") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.find_first_of("aeiou", 0) == 1);
     REQUIRE(testString.find_first_of("aeiou", 2) == 4);
@@ -4882,7 +4927,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of empty character set") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_of(FixedString<16>("")) == FixedString<32>::npos);
     REQUIRE(testString.find_first_of(std::string("")) == FixedString<32>::npos);
@@ -4890,7 +4935,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of in empty string") {
-    constexpr const FixedString<32> testString("");
+    constexpr FixedString<32> testString("");
 
     REQUIRE(testString.find_first_of(FixedString<16>("aeiou")) == FixedString<32>::npos);
     REQUIRE(testString.find_first_of(std::string("aeiou")) == FixedString<32>::npos);
@@ -4899,14 +4944,14 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of with position beyond string size") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.find_first_of("aeiou", 10) == FixedString<32>::npos);
     REQUIRE(testString.find_first_of('a', 10) == FixedString<32>::npos);
   }
 
   SECTION("Find first of with repeated characters") {
-    constexpr const FixedString<32> testString("aaaaa");
+    constexpr FixedString<32> testString("aaaaa");
 
     REQUIRE(testString.find_first_of("a") == 0);
     REQUIRE(testString.find_first_of("ab") == 0);
@@ -4914,7 +4959,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of with multiple character sets") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_of("Hl") == 0); // 'H' at position 0
     REQUIRE(testString.find_first_of("lo") == 2); // 'l' at position 2
@@ -4923,7 +4968,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of case sensitivity") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_of("h") == FixedString<32>::npos);
     REQUIRE(testString.find_first_of("H") == 0);
@@ -4932,7 +4977,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of with special characters") {
-    constexpr const FixedString<32> testString("Hello, World!");
+    constexpr FixedString<32> testString("Hello, World!");
 
     REQUIRE(testString.find_first_of("!,") == 5); // ',' at position 5
     REQUIRE(testString.find_first_of("!") == 12); // '!' at position 12
@@ -4940,7 +4985,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of with numbers") {
-    constexpr const FixedString<32> testString("Hello123World");
+    constexpr FixedString<32> testString("Hello123World");
 
     REQUIRE(testString.find_first_of("0123456789") == 5); // '1' at position 5
     REQUIRE(testString.find_first_of("123") == 5); // '1' at position 5
@@ -4948,7 +4993,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of with whitespace") {
-    constexpr const FixedString<32> testString("Hello World\t\n");
+    constexpr FixedString<32> testString("Hello World\t\n");
 
     REQUIRE(testString.find_first_of(" \t\n") == 5); // ' ' at position 5
     REQUIRE(testString.find_first_of("\t") == 11);
@@ -4956,7 +5001,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of with different FixedString capacities") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_of(FixedString<8>("aeiou")) == 1);
     REQUIRE(testString.find_first_of(FixedString<16>("aeiou")) == 1);
@@ -4964,7 +5009,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of with single character string") {
-    constexpr const FixedString<32> testString("A");
+    constexpr FixedString<32> testString("A");
 
     REQUIRE(testString.find_first_of("A") == 0);
     REQUIRE(testString.find_first_of('A') == 0);
@@ -4973,7 +5018,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of with position 0") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_of("aeiou", 0) == 1);
     REQUIRE(testString.find_first_of("H", 0) == 0);
@@ -4981,7 +5026,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of with all characters found") {
-    constexpr const FixedString<32> testString("abcdefghijklmnopqrstuvwxyz");
+    constexpr FixedString<32> testString("abcdefghijklmnopqrstuvwxyz");
 
     REQUIRE(testString.find_first_of("aeiou") == 0);
     REQUIRE(testString.find_first_of("xyz") == 23);
@@ -4989,7 +5034,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first of with no characters found") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_of("0123456789") == FixedString<32>::npos);
     REQUIRE(testString.find_first_of("!@#$%^&*()") == FixedString<32>::npos);
@@ -4999,7 +5044,7 @@ TEST_CASE("FixedString find_first_of", "[core][fixed_string]") {
 
 TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   SECTION("Find first not of FixedString characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_not_of(FixedString<16>("H")) == 1); // 'e' at position 1
     REQUIRE(testString.find_first_not_of(FixedString<16>("Hel")) == 4); // 'o' at position 4
@@ -5007,7 +5052,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of StringLike characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_not_of(std::string("H")) == 1); // 'e' at position 1
     REQUIRE(testString.find_first_not_of(std::string("Hel")) == 4); // 'o' at position 4
@@ -5015,7 +5060,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of C string characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_not_of("H") == 1); // 'e' at position 1
     REQUIRE(testString.find_first_not_of("Hel") == 4); // 'o' at position 4
@@ -5023,7 +5068,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of single character") {
-    constexpr const FixedString<32> testString("aaaaab");
+    constexpr FixedString<32> testString("aaaaab");
 
     REQUIRE(testString.find_first_not_of('a') == 5); // 'b' at position 5
     REQUIRE(testString.find_first_not_of('b') == 0); // 'a' at position 0
@@ -5031,7 +5076,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with position parameter") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.find_first_not_of("Hel", 0) == 4); // 'o' at position 4
     REQUIRE(testString.find_first_not_of("Hel", 4) == 4); // 'o' at position 4
@@ -5041,7 +5086,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of empty character set") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_not_of(FixedString<16>("")) == 0); // 'H' at position 0
     REQUIRE(testString.find_first_not_of(std::string("")) == 0); // 'H' at position 0
@@ -5050,7 +5095,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of in empty string") {
-    constexpr const FixedString<32> testString("");
+    constexpr FixedString<32> testString("");
 
     REQUIRE(testString.find_first_not_of(FixedString<16>("aeiou")) == FixedString<32>::npos);
     REQUIRE(testString.find_first_not_of(std::string("aeiou")) == FixedString<32>::npos);
@@ -5059,14 +5104,14 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with position beyond string size") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.find_first_not_of("aeiou", 10) == FixedString<32>::npos);
     REQUIRE(testString.find_first_not_of('a', 10) == FixedString<32>::npos);
   }
 
   SECTION("Find first not of with repeated characters") {
-    constexpr const FixedString<32> testString("aaaaa");
+    constexpr FixedString<32> testString("aaaaa");
 
     REQUIRE(testString.find_first_not_of("a") == FixedString<32>::npos);
     REQUIRE(testString.find_first_not_of("ab") == FixedString<32>::npos);
@@ -5074,7 +5119,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with multiple character sets") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_not_of("Hl") == 1); // 'e' at position 1
     REQUIRE(testString.find_first_not_of("Hel") == 4); // 'o' at position 4
@@ -5083,7 +5128,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of case sensitivity") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_not_of("h") == 0); // 'H' at position 0
     REQUIRE(testString.find_first_not_of("H") == 1); // 'e' at position 1
@@ -5092,14 +5137,14 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with special characters") {
-    constexpr const FixedString<32> testString("Hello, World!");
+    constexpr FixedString<32> testString("Hello, World!");
 
     REQUIRE(testString.find_first_not_of("Helo, Wrd!") == FixedString<32>::npos);
     REQUIRE(testString.find_first_not_of("Helo, Wrd") == 12); // '!' at position 12
   }
 
   SECTION("Find first not of with numbers") {
-    constexpr const FixedString<32> testString("Hello123World");
+    constexpr FixedString<32> testString("Hello123World");
 
     REQUIRE(testString.find_first_not_of("0123456789") == 0); // 'H' at position 0
     REQUIRE(testString.find_first_not_of("Helo123Wrd") == FixedString<32>::npos);
@@ -5107,7 +5152,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with whitespace") {
-    constexpr const FixedString<32> testString("Hello World\t\n");
+    constexpr FixedString<32> testString("Hello World\t\n");
 
     REQUIRE(testString.find_first_not_of(" \t\n") == 0); // 'H' at position 0
     REQUIRE(testString.find_first_not_of("Helo Wrd\t\n") == FixedString<32>::npos);
@@ -5115,7 +5160,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with different FixedString capacities") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_not_of(FixedString<8>("H")) == 1);
     REQUIRE(testString.find_first_not_of(FixedString<16>("H")) == 1);
@@ -5123,7 +5168,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with single character string") {
-    constexpr const FixedString<32> testString("A");
+    constexpr FixedString<32> testString("A");
 
     REQUIRE(testString.find_first_not_of("A") == FixedString<32>::npos);
     REQUIRE(testString.find_first_not_of('A') == FixedString<32>::npos);
@@ -5132,7 +5177,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with position 0") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_not_of("H", 0) == 1);
     REQUIRE(testString.find_first_not_of("Hel", 0) == 4);
@@ -5140,7 +5185,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with all characters excluded") {
-    constexpr const FixedString<32> testString("abcdefghijklmnopqrstuvwxyz");
+    constexpr FixedString<32> testString("abcdefghijklmnopqrstuvwxyz");
 
     REQUIRE(testString.find_first_not_of("abcdefghijklmnopqrstuvwxyz") == FixedString<32>::npos);
     REQUIRE(testString.find_first_not_of("abcdefghijklmnopqrstuvwxy") == 25); // 'z' at position 25
@@ -5148,7 +5193,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with no characters excluded") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_first_not_of("xyz") == 0); // 'H' at position 0
     REQUIRE(testString.find_first_not_of("0123456789") == 0); // 'H' at position 0
@@ -5156,7 +5201,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with mixed content") {
-    constexpr const FixedString<32> testString("Hello123World");
+    constexpr FixedString<32> testString("Hello123World");
 
     REQUIRE(testString.find_first_not_of("Helo123Wrd") == FixedString<32>::npos);
     REQUIRE(testString.find_first_not_of("Helo123Wr") == 12); // 'd' at position 12
@@ -5164,7 +5209,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with position in middle") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.find_first_not_of("Hel", 4) == 4); // 'o' at position 4
     REQUIRE(testString.find_first_not_of("Hel", 5) == 5); // ' ' at position 5
@@ -5173,7 +5218,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find first not of with exact match") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.find_first_not_of("Hello") == FixedString<32>::npos);
     REQUIRE(testString.find_first_not_of("Hell") == 4); // 'o' at position 4
@@ -5183,7 +5228,7 @@ TEST_CASE("FixedString find_first_not_of", "[core][fixed_string]") {
 
 TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   SECTION("Find last of FixedString characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_of(FixedString<16>("aeiou")) == 7); // 'o' at position 7
     REQUIRE(testString.find_last_of(FixedString<16>("l")) == 9); // 'l' at position 9
@@ -5192,7 +5237,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of StringLike characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_of(std::string("aeiou")) == 7); // 'o' at position 7
     REQUIRE(testString.find_last_of(std::string("l")) == 9); // 'l' at position 9
@@ -5201,7 +5246,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of C string characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_of("aeiou") == 7); // 'o' at position 7
     REQUIRE(testString.find_last_of("l") == 9); // 'l' at position 9
@@ -5210,7 +5255,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of single character") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_of('l') == 9); // 'l' at position 9
     REQUIRE(testString.find_last_of('o') == 7); // 'o' at position 7
@@ -5219,7 +5264,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with position parameter") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.find_last_of("Hel", 8) == 3); // 'l' at position 3
     REQUIRE(testString.find_last_of("Hel", 4) == 3); // 'l' at position 3
@@ -5229,7 +5274,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of empty character set") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_of(FixedString<16>("")) == FixedString<32>::npos);
     REQUIRE(testString.find_last_of(std::string("")) == FixedString<32>::npos);
@@ -5237,7 +5282,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with no characters found") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_of("0123456789") == FixedString<32>::npos);
     REQUIRE(testString.find_last_of("!@#$%^&*()") == FixedString<32>::npos);
@@ -5245,7 +5290,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with multiple character sets") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_of("Hl") == 9); // 'l' at position 9
     REQUIRE(testString.find_last_of("Hel") == 9); // 'l' at position 9
@@ -5254,7 +5299,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of case sensitivity") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_of("h") == FixedString<32>::npos);
     REQUIRE(testString.find_last_of("H") == 0); // 'H' at position 0
@@ -5263,7 +5308,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with special characters") {
-    constexpr const FixedString<32> testString("Hello, World!");
+    constexpr FixedString<32> testString("Hello, World!");
 
     REQUIRE(testString.find_last_of("Helo, Wrd!") == 12); // '!' at position 12
     REQUIRE(testString.find_last_of("Helo, Wrd") == 11); // 'd' at position 11
@@ -5271,7 +5316,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with numbers") {
-    constexpr const FixedString<32> testString("Hello123World");
+    constexpr FixedString<32> testString("Hello123World");
 
     REQUIRE(testString.find_last_of("0123456789") == 7); // '3' at position 7
     REQUIRE(testString.find_last_of("Helo123Wrd") == 12); // 'd' at position 12
@@ -5279,7 +5324,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with whitespace") {
-    constexpr const FixedString<32> testString("Hello World\t\n");
+    constexpr FixedString<32> testString("Hello World\t\n");
 
     REQUIRE(testString.find_last_of(" \t\n") == 12); // '\n' at position 12
     REQUIRE(testString.find_last_of("Helo Wrd\t\n") == 12); // '\n' at position 12
@@ -5287,7 +5332,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with repeated characters") {
-    constexpr const FixedString<32> testString("aaaaab");
+    constexpr FixedString<32> testString("aaaaab");
 
     REQUIRE(testString.find_last_of('a') == 4); // 'a' at position 4
     REQUIRE(testString.find_last_of('b') == 5); // 'b' at position 5
@@ -5295,7 +5340,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with single character string") {
-    constexpr const FixedString<32> testString("AAAAA");
+    constexpr FixedString<32> testString("AAAAA");
 
     REQUIRE(testString.find_last_of("A") == 4); // 'A' at position 4
     REQUIRE(testString.find_last_of('A') == 4); // 'A' at position 4
@@ -5304,7 +5349,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with alphabet") {
-    constexpr const FixedString<32> testString("abcdefghijklmnopqrstuvwxyz");
+    constexpr FixedString<32> testString("abcdefghijklmnopqrstuvwxyz");
 
     REQUIRE(testString.find_last_of("abcdefghijklmnopqrstuvwxyz") == 25); // 'z' at position 25
     REQUIRE(testString.find_last_of("abcdefghijklmnopqrstuvwxy") == 24); // 'y' at position 24
@@ -5312,7 +5357,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with all characters found") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_of("Helo Wrd") == 10); // 'd' at position 10
     REQUIRE(testString.find_last_of("Helo Wr") == 9); // 'l' at position 9
@@ -5320,7 +5365,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with position in middle") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.find_last_of("Hel", 8) == 3); // 'l' at position 3
     REQUIRE(testString.find_last_of("Hel", 4) == 3); // 'l' at position 3
@@ -5329,7 +5374,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last of with exact match") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.find_last_of("Hello") == 4); // 'o' at position 4
     REQUIRE(testString.find_last_of("Hell") == 3); // 'l' at position 3
@@ -5339,7 +5384,7 @@ TEST_CASE("FixedString find_last_of", "[core][fixed_string]") {
 
 TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   SECTION("Find last not of FixedString characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_not_of(FixedString<16>("d")) == 9); // 'l' at position 9
     REQUIRE(testString.find_last_not_of(FixedString<16>("ld")) == 8); // 'r' at position 8
@@ -5348,7 +5393,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of StringLike characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_not_of(std::string("d")) == 9); // 'l' at position 9
     REQUIRE(testString.find_last_not_of(std::string("ld")) == 8); // 'r' at position 8
@@ -5357,7 +5402,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of C string characters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_not_of("d") == 9); // 'l' at position 9
     REQUIRE(testString.find_last_not_of("ld") == 8); // 'r' at position 8
@@ -5366,7 +5411,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of single character") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_not_of('d') == 9); // 'l' at position 9
     REQUIRE(testString.find_last_not_of('l') == 10); // 'd' at position 10
@@ -5375,7 +5420,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with position parameter") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.find_last_not_of("Hel", 8) == 8); // 'r' at position 8
     REQUIRE(testString.find_last_not_of("Hel", 4) == 4); // 'o' at position 4
@@ -5385,7 +5430,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of empty character set") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_not_of(FixedString<16>("")) == 10); // 'd' at position 10
     REQUIRE(testString.find_last_not_of(std::string("")) == 10); // 'd' at position 10
@@ -5394,7 +5439,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with all characters excluded") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_not_of("Helo Wrd") == FixedString<32>::npos);
     REQUIRE(testString.find_last_not_of("Helo Wr") == 10); // 'd' at position 10
@@ -5402,7 +5447,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with multiple character sets") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_not_of("Hl") == 10); // 'd' at position 10
     REQUIRE(testString.find_last_not_of("Hel") == 10); // 'd' at position 10
@@ -5411,7 +5456,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of case sensitivity") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_not_of("h") == 10); // 'd' at position 10
     REQUIRE(testString.find_last_not_of("H") == 10); // 'd' at position 10
@@ -5420,7 +5465,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with special characters") {
-    constexpr const FixedString<32> testString("Hello, World!");
+    constexpr FixedString<32> testString("Hello, World!");
 
     REQUIRE(testString.find_last_not_of("Helo, Wrd!") == FixedString<32>::npos);
     REQUIRE(testString.find_last_not_of("Helo, Wrd") == 12); // '!' at position 12
@@ -5428,7 +5473,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with numbers") {
-    constexpr const FixedString<32> testString("Hello123World");
+    constexpr FixedString<32> testString("Hello123World");
 
     REQUIRE(testString.find_last_not_of("0123456789") == 12); // 'd' at position 12
     REQUIRE(testString.find_last_not_of("Helo123Wrd") == FixedString<32>::npos);
@@ -5436,7 +5481,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with whitespace") {
-    constexpr const FixedString<32> testString("Hello World\t\n");
+    constexpr FixedString<32> testString("Hello World\t\n");
 
     REQUIRE(testString.find_last_not_of(" \t\n") == 10); // 'd' at position 10
     REQUIRE(testString.find_last_not_of("Helo Wrd\t\n") == FixedString<32>::npos);
@@ -5444,7 +5489,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with repeated characters") {
-    constexpr const FixedString<32> testString("aaaaab");
+    constexpr FixedString<32> testString("aaaaab");
 
     REQUIRE(testString.find_last_not_of('a') == 5); // 'b' at position 5
     REQUIRE(testString.find_last_not_of('b') == 4); // 'a' at position 4
@@ -5452,7 +5497,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with single character string") {
-    constexpr const FixedString<32> testString("AAAAA");
+    constexpr FixedString<32> testString("AAAAA");
 
     REQUIRE(testString.find_last_not_of("A") == FixedString<32>::npos);
     REQUIRE(testString.find_last_not_of('A') == FixedString<32>::npos);
@@ -5461,7 +5506,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with alphabet") {
-    constexpr const FixedString<32> testString("abcdefghijklmnopqrstuvwxyz");
+    constexpr FixedString<32> testString("abcdefghijklmnopqrstuvwxyz");
 
     REQUIRE(testString.find_last_not_of("abcdefghijklmnopqrstuvwxyz") == FixedString<32>::npos);
     REQUIRE(testString.find_last_not_of("abcdefghijklmnopqrstuvwxy") == 25); // 'z' at position 25
@@ -5469,7 +5514,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with no characters excluded") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.find_last_not_of("xyz") == 10); // 'd' at position 10
     REQUIRE(testString.find_last_not_of("0123456789") == 10); // 'd' at position 10
@@ -5477,7 +5522,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with position in middle") {
-    constexpr const FixedString<32> testString("Hello World Hello");
+    constexpr FixedString<32> testString("Hello World Hello");
 
     REQUIRE(testString.find_last_not_of("Hel", 8) == 8); // 'r' at position 8
     REQUIRE(testString.find_last_not_of("Hel", 4) == 4); // 'o' at position 4
@@ -5486,7 +5531,7 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
   }
 
   SECTION("Find last not of with exact match") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.find_last_not_of("Hello") == FixedString<32>::npos);
     REQUIRE(testString.find_last_not_of("Hell") == 4); // 'o' at position 4
@@ -5496,10 +5541,10 @@ TEST_CASE("FixedString find_last_not_of", "[core][fixed_string]") {
 
 TEST_CASE("FixedString compare", "[core][fixed_string]") {
   SECTION("Compare FixedString with FixedString") {
-    constexpr const FixedString<32> testString1("Hello");
-    constexpr const FixedString<32> testString2("Hello");
-    constexpr const FixedString<32> testString3("World");
-    constexpr const FixedString<32> testString4("Hell");
+    constexpr FixedString<32> testString1("Hello");
+    constexpr FixedString<32> testString2("Hello");
+    constexpr FixedString<32> testString3("World");
+    constexpr FixedString<32> testString4("Hell");
 
     REQUIRE(testString1.compare(testString2) == 0);
     REQUIRE(testString1.compare(testString3) < 0);
@@ -5507,7 +5552,7 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare FixedString with StringLike") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.compare(std::string("Hello")) == 0);
     REQUIRE(testString.compare(std::string("World")) < 0);
@@ -5515,7 +5560,7 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare FixedString with C string") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.compare("Hello") == 0);
     REQUIRE(testString.compare("World") < 0);
@@ -5523,7 +5568,7 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare identical strings") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.compare(FixedString<32>("Hello World")) == 0);
     REQUIRE(testString.compare(std::string("Hello World")) == 0);
@@ -5531,8 +5576,8 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare with empty strings") {
-    constexpr const FixedString<32> testString1("");
-    constexpr const FixedString<32> testString2("Hello");
+    constexpr FixedString<32> testString1("");
+    constexpr FixedString<32> testString2("Hello");
 
     REQUIRE(testString1.compare(testString2) < 0);
     REQUIRE(testString2.compare(testString1) > 0);
@@ -5541,47 +5586,47 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare strings with different lengths") {
-    constexpr const FixedString<32> testString1("Hello");
-    constexpr const FixedString<32> testString2("Hello World");
+    constexpr FixedString<32> testString1("Hello");
+    constexpr FixedString<32> testString2("Hello World");
 
     REQUIRE(testString1.compare(testString2) < 0);
     REQUIRE(testString2.compare(testString1) > 0);
   }
 
   SECTION("Compare strings with same prefix") {
-    constexpr const FixedString<32> testString1("Hello");
-    constexpr const FixedString<32> testString2("Hell");
+    constexpr FixedString<32> testString1("Hello");
+    constexpr FixedString<32> testString2("Hell");
 
     REQUIRE(testString1.compare(testString2) > 0);
     REQUIRE(testString2.compare(testString1) < 0);
   }
 
   SECTION("Compare strings with different first character") {
-    constexpr const FixedString<32> testString1("Apple");
-    constexpr const FixedString<32> testString2("Banana");
+    constexpr FixedString<32> testString1("Apple");
+    constexpr FixedString<32> testString2("Banana");
 
     REQUIRE(testString1.compare(testString2) < 0);
     REQUIRE(testString2.compare(testString1) > 0);
   }
 
   SECTION("Compare strings with different middle character") {
-    constexpr const FixedString<32> testString1("Hello");
-    constexpr const FixedString<32> testString2("Hallo");
+    constexpr FixedString<32> testString1("Hello");
+    constexpr FixedString<32> testString2("Hallo");
 
     REQUIRE(testString1.compare(testString2) > 0);
     REQUIRE(testString2.compare(testString1) < 0);
   }
 
   SECTION("Compare strings with different last character") {
-    constexpr const FixedString<32> testString1("Hello");
-    constexpr const FixedString<32> testString2("Hellp");
+    constexpr FixedString<32> testString1("Hello");
+    constexpr FixedString<32> testString2("Hellp");
 
     REQUIRE(testString1.compare(testString2) < 0);
     REQUIRE(testString2.compare(testString1) > 0);
   }
 
   SECTION("Compare case sensitivity") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.compare("hello") < 0);
     REQUIRE(testString.compare("HELLO") > 0);
@@ -5589,7 +5634,7 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare with different FixedString capacities") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.compare(FixedString<8>("Hello")) == 0);
     REQUIRE(testString.compare(FixedString<16>("Hello")) == 0);
@@ -5599,8 +5644,8 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare with single character strings") {
-    constexpr const FixedString<32> testString1("A");
-    constexpr const FixedString<32> testString2("B");
+    constexpr FixedString<32> testString1("A");
+    constexpr FixedString<32> testString2("B");
 
     REQUIRE(testString1.compare(testString2) < 0);
     REQUIRE(testString2.compare(testString1) > 0);
@@ -5609,8 +5654,8 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare with repeated characters") {
-    constexpr const FixedString<32> testString1("aaa");
-    constexpr const FixedString<32> testString2("aa");
+    constexpr FixedString<32> testString1("aaa");
+    constexpr FixedString<32> testString2("aa");
 
     REQUIRE(testString1.compare(testString2) > 0);
     REQUIRE(testString2.compare(testString1) < 0);
@@ -5619,8 +5664,8 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare with special characters") {
-    constexpr const FixedString<32> testString1("Hello!");
-    constexpr const FixedString<32> testString2("Hello");
+    constexpr FixedString<32> testString1("Hello!");
+    constexpr FixedString<32> testString2("Hello");
 
     REQUIRE(testString1.compare(testString2) > 0);
     REQUIRE(testString2.compare(testString1) < 0);
@@ -5629,8 +5674,8 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare with numbers") {
-    constexpr const FixedString<32> testString1("123");
-    constexpr const FixedString<32> testString2("456");
+    constexpr FixedString<32> testString1("123");
+    constexpr FixedString<32> testString2("456");
 
     REQUIRE(testString1.compare(testString2) < 0);
     REQUIRE(testString2.compare(testString1) > 0);
@@ -5639,8 +5684,8 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare with mixed content") {
-    constexpr const FixedString<32> testString1("Hello123");
-    constexpr const FixedString<32> testString2("Hello456");
+    constexpr FixedString<32> testString1("Hello123");
+    constexpr FixedString<32> testString2("Hello456");
 
     REQUIRE(testString1.compare(testString2) < 0);
     REQUIRE(testString2.compare(testString1) > 0);
@@ -5649,8 +5694,8 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare with maximum length strings") {
-    constexpr const FixedString<16> testString1("123456789012345");
-    constexpr const FixedString<16> testString2("123456789012346");
+    constexpr FixedString<16> testString1("123456789012345");
+    constexpr FixedString<16> testString2("123456789012346");
 
     REQUIRE(testString1.compare(testString2) < 0);
     REQUIRE(testString2.compare(testString1) > 0);
@@ -5659,7 +5704,7 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare with std::string") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.compare(std::string("Hello World")) == 0);
     REQUIRE(testString.compare(std::string("Hello")) > 0);
@@ -5667,7 +5712,7 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare with array") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
     constexpr std::array<char, 6> arr = {'H', 'e', 'l', 'l', 'o', '\0'};
 
     REQUIRE(testString.compare(arr.data()) == 0);
@@ -5675,20 +5720,20 @@ TEST_CASE("FixedString compare", "[core][fixed_string]") {
   }
 
   SECTION("Compare edge cases") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     // Compare with null-terminated string
     REQUIRE(testString.compare("Hello\0World") == 0);
 
     // Compare with string containing null character
-    constexpr const FixedString<32> testStringWithNull("Hello\0World");
+    constexpr FixedString<32> testStringWithNull("Hello\0World");
     REQUIRE(testString.compare(testStringWithNull) == 0);
   }
 }
 
 TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   SECTION("Starts with FixedString") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.starts_with(FixedString<16>("Hello")) == true);
     REQUIRE(testString.starts_with(FixedString<16>("Hello World")) == true);
@@ -5699,7 +5744,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with StringLike") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.starts_with(std::string("Hello")) == true);
     REQUIRE(testString.starts_with(std::string("Hello World")) == true);
@@ -5710,7 +5755,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with C string") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.starts_with("Hello") == true);
     REQUIRE(testString.starts_with("Hello World") == true);
@@ -5721,7 +5766,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with character") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.starts_with('H') == true);
     REQUIRE(testString.starts_with('h') == false);
@@ -5730,7 +5775,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with empty string") {
-    constexpr const FixedString<32> testString("");
+    constexpr FixedString<32> testString("");
 
     REQUIRE(testString.starts_with(FixedString<16>("Hello")) == false);
     REQUIRE(testString.starts_with(std::string("Hello")) == false);
@@ -5740,7 +5785,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with single character string") {
-    constexpr const FixedString<32> testString("A");
+    constexpr FixedString<32> testString("A");
 
     REQUIRE(testString.starts_with("A") == true);
     REQUIRE(testString.starts_with('A') == true);
@@ -5750,7 +5795,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with longer prefix") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.starts_with("Hello World") == false);
     REQUIRE(testString.starts_with("Hello Universe") == false);
@@ -5759,7 +5804,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with case sensitivity") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.starts_with("hello") == false);
     REQUIRE(testString.starts_with("HELLO") == false);
@@ -5769,7 +5814,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with different FixedString capacities") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.starts_with(FixedString<8>("Hello")) == true);
     REQUIRE(testString.starts_with(FixedString<16>("Hello")) == true);
@@ -5778,7 +5823,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with repeated characters") {
-    constexpr const FixedString<32> testString("aaaab");
+    constexpr FixedString<32> testString("aaaab");
 
     REQUIRE(testString.starts_with("aaa") == true);
     REQUIRE(testString.starts_with("aaaa") == true);
@@ -5789,7 +5834,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with special characters") {
-    constexpr const FixedString<32> testString("!@#$%");
+    constexpr FixedString<32> testString("!@#$%");
 
     REQUIRE(testString.starts_with("!@#") == true);
     REQUIRE(testString.starts_with("!@#$%") == true);
@@ -5799,7 +5844,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with numbers") {
-    constexpr const FixedString<32> testString("12345");
+    constexpr FixedString<32> testString("12345");
 
     REQUIRE(testString.starts_with("123") == true);
     REQUIRE(testString.starts_with("12345") == true);
@@ -5809,7 +5854,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with mixed content") {
-    constexpr const FixedString<32> testString("Hello123");
+    constexpr FixedString<32> testString("Hello123");
 
     REQUIRE(testString.starts_with("Hello") == true);
     REQUIRE(testString.starts_with("Hello1") == true);
@@ -5820,7 +5865,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with maximum length strings") {
-    constexpr const FixedString<16> testString("123456789012345");
+    constexpr FixedString<16> testString("123456789012345");
 
     REQUIRE(testString.starts_with("123456789012345") == true);
     REQUIRE(testString.starts_with("12345678901234") == true);
@@ -5830,7 +5875,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with std::string") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.starts_with(std::string("Hello")) == true);
     REQUIRE(testString.starts_with(std::string("Hello World")) == true);
@@ -5838,7 +5883,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with array") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
     constexpr std::array<char, 4> arr = {'H', 'e', 'l', '\0'};
 
     REQUIRE(testString.starts_with(arr.data()) == true);
@@ -5846,18 +5891,18 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with edge cases") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     // Test with null-terminated string
     REQUIRE(testString.starts_with("Hello\0World") == true);
 
     // Test with string containing null character
-    constexpr const FixedString<32> testStringWithNull("Hello\0World");
+    constexpr FixedString<32> testStringWithNull("Hello\0World");
     REQUIRE(testStringWithNull.starts_with("Hello") == true);
   }
 
   SECTION("Starts with whitespace") {
-    constexpr const FixedString<32> testString(" Hello World");
+    constexpr FixedString<32> testString(" Hello World");
 
     REQUIRE(testString.starts_with(" ") == true);
     REQUIRE(testString.starts_with(" Hello") == true);
@@ -5867,7 +5912,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
   }
 
   SECTION("Starts with exact match") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.starts_with("Hello") == true);
     REQUIRE(testString.starts_with("Hell") == true);
@@ -5880,7 +5925,7 @@ TEST_CASE("FixedString starts_with", "[core][fixed_string]") {
 
 TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   SECTION("FixedString ends_with") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.ends_with(FixedString<16>("World")) == true);
     REQUIRE(testString.ends_with(FixedString<16>("Hello World")) == true);
@@ -5899,7 +5944,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("StringLike ends_with") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.ends_with(std::string("World")) == true);
     REQUIRE(testString.ends_with(std::string("Hello World")) == true);
@@ -5918,7 +5963,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("C string ends_with") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.ends_with("World") == true);
     REQUIRE(testString.ends_with("Hello World") == true);
@@ -5937,7 +5982,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Character ends_with") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.ends_with('d') == true);
     REQUIRE(testString.ends_with('D') == false);
@@ -5952,7 +5997,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Empty string ends_with") {
-    constexpr const FixedString<32> testString("");
+    constexpr FixedString<32> testString("");
 
     REQUIRE(testString.ends_with(FixedString<16>("Hello")) == false);
     REQUIRE(testString.ends_with(std::string("Hello")) == false);
@@ -5969,7 +6014,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Single character string ends_with") {
-    constexpr const FixedString<32> testString("A");
+    constexpr FixedString<32> testString("A");
 
     REQUIRE(testString.ends_with("A") == true);
     REQUIRE(testString.ends_with('A') == true);
@@ -5986,7 +6031,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Longer suffix ends_with") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.ends_with("Hello World") == false);
     REQUIRE(testString.ends_with("Hello Universe") == false);
@@ -6001,7 +6046,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Case sensitivity ends_with") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.ends_with("world") == false);
     REQUIRE(testString.ends_with("WORLD") == false);
@@ -6018,7 +6063,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Different FixedString capacities ends_with") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.ends_with(FixedString<8>("World")) == true);
     REQUIRE(testString.ends_with(FixedString<16>("World")) == true);
@@ -6033,7 +6078,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Repeated characters ends_with") {
-    constexpr const FixedString<32> testString("baaaa");
+    constexpr FixedString<32> testString("baaaa");
 
     REQUIRE(testString.ends_with("aaa") == true);
     REQUIRE(testString.ends_with("aaaa") == true);
@@ -6052,7 +6097,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Special characters ends_with") {
-    constexpr const FixedString<32> testString("%$#@!");
+    constexpr FixedString<32> testString("%$#@!");
 
     REQUIRE(testString.ends_with("@!") == true);
     REQUIRE(testString.ends_with("%$#@!") == true);
@@ -6069,7 +6114,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Numeric content ends_with") {
-    constexpr const FixedString<32> testString("54321");
+    constexpr FixedString<32> testString("54321");
 
     REQUIRE(testString.ends_with("321") == true);
     REQUIRE(testString.ends_with("54321") == true);
@@ -6086,7 +6131,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Mixed content ends_with") {
-    constexpr const FixedString<32> testString("123Hello");
+    constexpr FixedString<32> testString("123Hello");
 
     REQUIRE(testString.ends_with("Hello") == true);
     REQUIRE(testString.ends_with("3Hello") == true);
@@ -6105,7 +6150,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Maximum length strings ends_with") {
-    constexpr const FixedString<16> testString("123456789012345");
+    constexpr FixedString<16> testString("123456789012345");
 
     REQUIRE(testString.ends_with("123456789012345") == true);
     REQUIRE(testString.ends_with("23456789012345") == true);
@@ -6122,7 +6167,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Array ends_with") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
     constexpr std::array<char, 4> arr = {'l', 'l', 'o', '\0'};
 
     REQUIRE(testString.ends_with(arr.data()) == true);
@@ -6134,13 +6179,13 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Edge cases ends_with") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     // Test with null-terminated string
     REQUIRE(testString.ends_with("Hello\0World") == true);
 
     // Test with string containing null character
-    constexpr const FixedString<32> testStringWithNull("Hello\0World");
+    constexpr FixedString<32> testStringWithNull("Hello\0World");
     REQUIRE(testStringWithNull.ends_with("World") == false);
 
     // Compile-time checks
@@ -6149,7 +6194,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Whitespace ends_with") {
-    constexpr const FixedString<32> testString("Hello World ");
+    constexpr FixedString<32> testString("Hello World ");
 
     REQUIRE(testString.ends_with(" ") == true);
     REQUIRE(testString.ends_with("World ") == true);
@@ -6166,7 +6211,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Exact match ends_with") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.ends_with("Hello") == true);
     REQUIRE(testString.ends_with("llo") == true);
@@ -6181,7 +6226,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Overlapping patterns ends_with") {
-    constexpr const FixedString<32> testString("ababab");
+    constexpr FixedString<32> testString("ababab");
 
     REQUIRE(testString.ends_with("ab") == true);
     REQUIRE(testString.ends_with("bab") == true);
@@ -6200,7 +6245,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Multiple occurrences ends_with") {
-    constexpr const FixedString<32> testString("abababab");
+    constexpr FixedString<32> testString("abababab");
 
     REQUIRE(testString.ends_with("ab") == true);
     REQUIRE(testString.ends_with("bab") == true);
@@ -6217,7 +6262,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Unicode content ends_with") {
-    constexpr const FixedString<32> testString("Hello 世界");
+    constexpr FixedString<32> testString("Hello 世界");
 
     REQUIRE(testString.ends_with("世界") == true);
     REQUIRE(testString.ends_with("Hello 世界") == true);
@@ -6236,7 +6281,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Long strings ends_with") {
-    constexpr const FixedString<64> testString("This is a very long string for performance testing");
+    constexpr FixedString<64> testString("This is a very long string for performance testing");
 
     REQUIRE(testString.ends_with("testing") == true);
     REQUIRE(testString.ends_with("performance testing") == true);
@@ -6255,9 +6300,9 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr operations ends_with") {
-    constexpr const FixedString<16> str1("Hello");
-    constexpr const FixedString<16> str2("World");
-    constexpr const FixedString<16> str3("Test");
+    constexpr FixedString<16> str1("Hello");
+    constexpr FixedString<16> str2("World");
+    constexpr FixedString<16> str3("Test");
 
     // Compile-time ends_with operations
     constexpr bool ends1 = str1.ends_with("llo");
@@ -6281,7 +6326,7 @@ TEST_CASE("FixedString ends_with", "[core][fixed_string]") {
 
 TEST_CASE("FixedString contains", "[core][fixed_string]") {
   SECTION("C string contains") {
-    constexpr const FixedString<32> str("Hello World");
+    constexpr FixedString<32> str("Hello World");
 
     // Basic contains
     REQUIRE(str.contains("World") == true);
@@ -6301,7 +6346,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("FixedString contains") {
-    constexpr const FixedString<16> str("Hello World");
+    constexpr FixedString<16> str("Hello World");
 
     // Basic contains with FixedString
     REQUIRE(str.contains(FixedString<16>("World")) == true);
@@ -6340,7 +6385,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("Character contains") {
-    constexpr const FixedString<32> str("Hello World");
+    constexpr FixedString<32> str("Hello World");
 
     // Character contains
     REQUIRE(str.contains('H') == true);
@@ -6360,7 +6405,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("Empty string contains") {
-    constexpr const FixedString<32> str("");
+    constexpr FixedString<32> str("");
 
     // Empty string contains
     REQUIRE(str.contains(FixedString<16>("Hello")) == false);
@@ -6377,7 +6422,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("Single character string contains") {
-    constexpr const FixedString<8> str("A");
+    constexpr FixedString<8> str("A");
 
     // Single character contains
     REQUIRE(str.contains("A") == true);
@@ -6395,7 +6440,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("Case sensitivity") {
-    constexpr const FixedString<32> str("Hello World");
+    constexpr FixedString<32> str("Hello World");
 
     // Case sensitive contains
     REQUIRE(str.contains("world") == false);
@@ -6413,7 +6458,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const FixedString<16> str("Hello");
+    constexpr FixedString<16> str("Hello");
 
     // Longer substring than string
     REQUIRE(str.contains("Hello World") == false);
@@ -6435,7 +6480,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("Special characters") {
-    constexpr const FixedString<32> str("Hello\n\tWorld!");
+    constexpr FixedString<32> str("Hello\n\tWorld!");
 
     // Special characters
     REQUIRE(str.contains("\n") == true);
@@ -6455,7 +6500,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("Unicode content") {
-    constexpr const FixedString<32> str("Hello 世界");
+    constexpr FixedString<32> str("Hello 世界");
 
     // Unicode contains
     REQUIRE(str.contains("世界") == true);
@@ -6473,7 +6518,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("Repeated patterns") {
-    constexpr const FixedString<32> str("ababab");
+    constexpr FixedString<32> str("ababab");
 
     // Overlapping patterns
     REQUIRE(str.contains("ab") == true);
@@ -6493,7 +6538,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("Numeric content") {
-    constexpr const FixedString<32> str("12345");
+    constexpr FixedString<32> str("12345");
 
     // Numeric contains
     REQUIRE(str.contains("123") == true);
@@ -6517,7 +6562,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("Mixed content") {
-    constexpr const FixedString<32> str("123Hello456");
+    constexpr FixedString<32> str("123Hello456");
 
     // Mixed alphanumeric contains
     REQUIRE(str.contains("123") == true);
@@ -6537,7 +6582,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
   }
 
   SECTION("Position-specific contains") {
-    constexpr const FixedString<32> str("Hello World");
+    constexpr FixedString<32> str("Hello World");
 
     // Beginning
     REQUIRE(str.contains("H") == true);
@@ -6569,7 +6614,7 @@ TEST_CASE("FixedString contains", "[core][fixed_string]") {
 
 TEST_CASE("FixedString substr", "[core][fixed_string]") {
   SECTION("Substr basic functionality") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.substr(0).size() == 11);
     REQUIRE(std::strcmp(testString.substr(0).c_str(), "Hello World") == 0);
@@ -6586,7 +6631,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with default parameters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.substr().size() == 11);
     REQUIRE(std::strcmp(testString.substr().c_str(), "Hello World") == 0);
@@ -6597,7 +6642,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with count parameter") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.substr(0, 1).size() == 1);
     REQUIRE(std::strcmp(testString.substr(0, 1).c_str(), "H") == 0);
@@ -6622,7 +6667,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with npos count") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.substr(0, FixedString<32>::npos).size() == 11);
     REQUIRE(std::strcmp(testString.substr(0, FixedString<32>::npos).c_str(), "Hello World") == 0);
@@ -6633,7 +6678,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with position at end") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.substr(11).size() == 0);
     REQUIRE(std::strcmp(testString.substr(11).c_str(), "") == 0);
@@ -6644,7 +6689,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr from empty string") {
-    constexpr const FixedString<32> testString("");
+    constexpr FixedString<32> testString("");
 
     REQUIRE(testString.substr(0).size() == 0);
     REQUIRE(std::strcmp(testString.substr(0).c_str(), "") == 0);
@@ -6655,7 +6700,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr single character") {
-    constexpr const FixedString<32> testString("A");
+    constexpr FixedString<32> testString("A");
 
     REQUIRE(testString.substr(0).size() == 1);
     REQUIRE(std::strcmp(testString.substr(0).c_str(), "A") == 0);
@@ -6670,7 +6715,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with repeated characters") {
-    constexpr const FixedString<32> testString("aaaaa");
+    constexpr FixedString<32> testString("aaaaa");
 
     REQUIRE(testString.substr(0).size() == 5);
     REQUIRE(std::strcmp(testString.substr(0).c_str(), "aaaaa") == 0);
@@ -6697,7 +6742,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with special characters") {
-    constexpr const FixedString<32> testString("Hello, World!");
+    constexpr FixedString<32> testString("Hello, World!");
 
     REQUIRE(testString.substr(5).size() == 8);
     REQUIRE(std::strcmp(testString.substr(5).c_str(), ", World!") == 0);
@@ -6712,7 +6757,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with numbers") {
-    constexpr const FixedString<32> testString("12345");
+    constexpr FixedString<32> testString("12345");
 
     REQUIRE(testString.substr(0).size() == 5);
     REQUIRE(std::strcmp(testString.substr(0).c_str(), "12345") == 0);
@@ -6739,7 +6784,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with whitespace") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.substr(5).size() == 6);
     REQUIRE(std::strcmp(testString.substr(5).c_str(), " World") == 0);
@@ -6752,7 +6797,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with newlines") {
-    constexpr const FixedString<32> testString("Hello\nWorld");
+    constexpr FixedString<32> testString("Hello\nWorld");
 
     REQUIRE(testString.substr(5).size() == 6);
     REQUIRE(std::strcmp(testString.substr(5).c_str(), "\nWorld") == 0);
@@ -6765,7 +6810,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with tabs") {
-    constexpr const FixedString<32> testString("Hello\tWorld");
+    constexpr FixedString<32> testString("Hello\tWorld");
 
     REQUIRE(testString.substr(5).size() == 6);
     REQUIRE(std::strcmp(testString.substr(5).c_str(), "\tWorld") == 0);
@@ -6778,7 +6823,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr maximum length") {
-    constexpr const FixedString<16> testString("123456789012345"); // 15 characters
+    constexpr FixedString<16> testString("123456789012345"); // 15 characters
 
     REQUIRE(testString.substr(0).size() == 15);
     REQUIRE(std::strcmp(testString.substr(0).c_str(), "123456789012345") == 0);
@@ -6795,7 +6840,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with mixed content") {
-    constexpr const FixedString<32> testString("123Hello");
+    constexpr FixedString<32> testString("123Hello");
 
     REQUIRE(testString.substr(0).size() == 8);
     REQUIRE(std::strcmp(testString.substr(0).c_str(), "123Hello") == 0);
@@ -6810,7 +6855,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with overlapping ranges") {
-    constexpr const FixedString<32> testString("abcdef");
+    constexpr FixedString<32> testString("abcdef");
 
     REQUIRE(testString.substr(0, 1).size() == 1);
     REQUIRE(std::strcmp(testString.substr(0, 1).c_str(), "a") == 0);
@@ -6837,7 +6882,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with exact string length") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.substr(0, 5).size() == 5);
     REQUIRE(std::strcmp(testString.substr(0, 5).c_str(), "Hello") == 0);
@@ -6854,7 +6899,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with zero count") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     REQUIRE(testString.substr(0, 0).size() == 0);
     REQUIRE(std::strcmp(testString.substr(0, 0).c_str(), "") == 0);
@@ -6867,7 +6912,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with position at string size") {
-    constexpr const FixedString<32> testString("Hello");
+    constexpr FixedString<32> testString("Hello");
 
     REQUIRE(testString.substr(5).size() == 0);
     REQUIRE(std::strcmp(testString.substr(5).c_str(), "") == 0);
@@ -6878,9 +6923,9 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with different FixedString capacities") {
-    constexpr const FixedString<8> smallString("Hello");
-    constexpr const FixedString<16> mediumString("Hello World");
-    constexpr const FixedString<32> largeString("Hello World Universe");
+    constexpr FixedString<8> smallString("Hello");
+    constexpr FixedString<16> mediumString("Hello World");
+    constexpr FixedString<32> largeString("Hello World Universe");
 
     REQUIRE(smallString.substr(0, 3).size() == 3);
     REQUIRE(std::strcmp(smallString.substr(0, 3).c_str(), "Hel") == 0);
@@ -6897,7 +6942,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with punctuation") {
-    constexpr const FixedString<32> testString("Hello, World!");
+    constexpr FixedString<32> testString("Hello, World!");
 
     REQUIRE(testString.substr(5, 1).size() == 1);
     REQUIRE(std::strcmp(testString.substr(5, 1).c_str(), ",") == 0);
@@ -6912,7 +6957,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Substr with unicode-like content") {
-    constexpr const FixedString<32> testString("Hello 世界");
+    constexpr FixedString<32> testString("Hello 世界");
 
     REQUIRE(testString.substr(0, 6).size() == 6);
     REQUIRE(std::strcmp(testString.substr(0, 6).c_str(), "Hello ") == 0);
@@ -6921,7 +6966,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr operations") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     // Basic constexpr substr operations
     constexpr auto substr1 = testString.substr(0);
@@ -6946,7 +6991,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr with default parameters") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     constexpr auto substr1 = testString.substr();
     constexpr auto substr2 = testString.substr(0);
@@ -6961,7 +7006,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr with count parameter") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     constexpr auto substr1 = testString.substr(0, 1);
     constexpr auto substr2 = testString.substr(0, 2);
@@ -6997,7 +7042,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr with npos count") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     constexpr auto substr1 = testString.substr(0, FixedString<32>::npos);
     constexpr auto substr2 = testString.substr(6, FixedString<32>::npos);
@@ -7012,7 +7057,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr with position at end") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     constexpr auto substr1 = testString.substr(11);
     constexpr auto substr2 = testString.substr(11, 0);
@@ -7027,7 +7072,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr from empty string") {
-    constexpr const FixedString<32> testString("");
+    constexpr FixedString<32> testString("");
 
     constexpr auto substr1 = testString.substr(0);
     constexpr auto substr2 = testString.substr(0, 0);
@@ -7042,7 +7087,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr single character") {
-    constexpr const FixedString<32> testString("A");
+    constexpr FixedString<32> testString("A");
 
     constexpr auto substr1 = testString.substr(0);
     constexpr auto substr2 = testString.substr(0, 1);
@@ -7063,7 +7108,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr with repeated characters") {
-    constexpr const FixedString<32> testString("aaaaa");
+    constexpr FixedString<32> testString("aaaaa");
 
     constexpr auto substr1 = testString.substr(0);
     constexpr auto substr2 = testString.substr(0, 1);
@@ -7102,7 +7147,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr with special characters") {
-    constexpr const FixedString<32> testString("Hello, World!");
+    constexpr FixedString<32> testString("Hello, World!");
 
     constexpr auto substr1 = testString.substr(5);
     constexpr auto substr2 = testString.substr(5, 1);
@@ -7123,7 +7168,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr with numbers") {
-    constexpr const FixedString<32> testString("12345");
+    constexpr FixedString<32> testString("12345");
 
     constexpr auto substr1 = testString.substr(0);
     constexpr auto substr2 = testString.substr(0, 1);
@@ -7162,7 +7207,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr with whitespace") {
-    constexpr const FixedString<32> testString("Hello World");
+    constexpr FixedString<32> testString("Hello World");
 
     constexpr auto substr1 = testString.substr(5);
     constexpr auto substr2 = testString.substr(5, 1);
@@ -7180,7 +7225,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr with newlines") {
-    constexpr const FixedString<32> testString("Hello\nWorld");
+    constexpr FixedString<32> testString("Hello\nWorld");
 
     constexpr auto substr1 = testString.substr(5);
     constexpr auto substr2 = testString.substr(5, 1);
@@ -7198,7 +7243,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr with tabs") {
-    constexpr const FixedString<32> testString("Hello\tWorld");
+    constexpr FixedString<32> testString("Hello\tWorld");
 
     constexpr auto substr1 = testString.substr(5);
     constexpr auto substr2 = testString.substr(5, 1);
@@ -7216,7 +7261,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr maximum length") {
-    constexpr const FixedString<16> testString("123456789012345"); // 15 characters
+    constexpr FixedString<16> testString("123456789012345"); // 15 characters
 
     constexpr auto substr1 = testString.substr(0);
     constexpr auto substr2 = testString.substr(0, 15);
@@ -7240,7 +7285,7 @@ TEST_CASE("FixedString substr", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr substr with unicode-like content") {
-    constexpr const FixedString<32> testString("Hello 世界");
+    constexpr FixedString<32> testString("Hello 世界");
 
     constexpr auto substr1 = testString.substr(0, 6);
     constexpr auto substr2 = testString.substr(6);
@@ -7356,8 +7401,8 @@ TEST_CASE("FixedString operators+", "[core][fixed_string]") {
   }
 
   SECTION("One empty string concatenation") {
-    constexpr const FixedString<20> str1("Hello");
-    constexpr const FixedString<20> str2("");
+    constexpr FixedString<20> str1("Hello");
+    constexpr FixedString<20> str2("");
     constexpr auto result1 = str1 + str2;
     constexpr auto result2 = str2 + str1;
 
@@ -7381,8 +7426,8 @@ TEST_CASE("FixedString operators+", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr concatenation") {
-    constexpr const FixedString<20> str1("Hello");
-    constexpr const FixedString<20> str2("World");
+    constexpr FixedString<20> str1("Hello");
+    constexpr FixedString<20> str2("World");
     constexpr auto result = str1 + str2;
 
     REQUIRE(result.size() == 10);
@@ -7551,7 +7596,7 @@ TEST_CASE("FixedString operators+", "[core][fixed_string]") {
   }
 
   SECTION("FixedString + char (constexpr operations)") {
-    constexpr const FixedString<20> str("Hello");
+    constexpr FixedString<20> str("Hello");
     constexpr char ch = '!';
     constexpr auto result = str + ch;
 
@@ -7563,7 +7608,7 @@ TEST_CASE("FixedString operators+", "[core][fixed_string]") {
 
   SECTION("char + FixedString (constexpr operations)") {
     constexpr char ch = '!';
-    constexpr const FixedString<20> str("Hello");
+    constexpr FixedString<20> str("Hello");
     constexpr auto result = ch + str;
 
     REQUIRE(result.size() == 6);
@@ -7575,12 +7620,12 @@ TEST_CASE("FixedString operators+", "[core][fixed_string]") {
 
 TEST_CASE("FixedString operator==", "[core][fixed_string]") {
   SECTION("FixedString == FixedString") {
-    constexpr const FixedString<16> str1("Hello");
-    constexpr const FixedString<32> str2("Hello");
-    constexpr const FixedString<16> str3("World");
-    constexpr const FixedString<8> str4("Hello");
-    constexpr const FixedString<16> empty1;
-    constexpr const FixedString<32> empty2;
+    constexpr FixedString<16> str1("Hello");
+    constexpr FixedString<32> str2("Hello");
+    constexpr FixedString<16> str3("World");
+    constexpr FixedString<8> str4("Hello");
+    constexpr FixedString<16> empty1;
+    constexpr FixedString<32> empty2;
 
     REQUIRE(str1 == str2);
     REQUIRE(str2 == str1);
@@ -7606,7 +7651,7 @@ TEST_CASE("FixedString operator==", "[core][fixed_string]") {
   }
 
   SECTION("FixedString == StringLike") {
-    constexpr const FixedString<16> str1("Hello");
+    constexpr FixedString<16> str1("Hello");
     const std::string str2("Hello");
     const std::string str3("World");
     const std::string empty;
@@ -7620,8 +7665,8 @@ TEST_CASE("FixedString operator==", "[core][fixed_string]") {
   }
 
   SECTION("FixedString == C string") {
-    constexpr const FixedString<16> str1("Hello");
-    constexpr const FixedString<16> empty;
+    constexpr FixedString<16> str1("Hello");
+    constexpr FixedString<16> empty;
 
     REQUIRE(str1 == "Hello");
     REQUIRE("Hello" == str1);
@@ -7643,10 +7688,10 @@ TEST_CASE("FixedString operator==", "[core][fixed_string]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const FixedString<16> str1("A");
-    constexpr const FixedString<16> str2("B");
-    constexpr const FixedString<16> empty1;
-    constexpr const FixedString<32> empty2;
+    constexpr FixedString<16> str1("A");
+    constexpr FixedString<16> str2("B");
+    constexpr FixedString<16> empty1;
+    constexpr FixedString<32> empty2;
 
     // Single character comparison
     REQUIRE(str1 == "A");
@@ -7671,8 +7716,8 @@ TEST_CASE("FixedString operator==", "[core][fixed_string]") {
     STATIC_REQUIRE("" == empty1);
 
     // Different sizes with same content
-    constexpr const FixedString<8> small("Hi");
-    constexpr const FixedString<16> large("Hi");
+    constexpr FixedString<8> small("Hi");
+    constexpr FixedString<16> large("Hi");
 
     REQUIRE(small == large);
     REQUIRE(large == small);
@@ -7682,9 +7727,9 @@ TEST_CASE("FixedString operator==", "[core][fixed_string]") {
   }
 
   SECTION("Special characters") {
-    constexpr const FixedString<16> str1("Hello\nWorld");
-    constexpr const FixedString<16> str2("Hello\tWorld");
-    constexpr const FixedString<16> str3("Hello World");
+    constexpr FixedString<16> str1("Hello\nWorld");
+    constexpr FixedString<16> str2("Hello\tWorld");
+    constexpr FixedString<16> str3("Hello World");
 
     REQUIRE(str1 == "Hello\nWorld");
     REQUIRE("Hello\nWorld" == str1);
@@ -7706,9 +7751,9 @@ TEST_CASE("FixedString operator==", "[core][fixed_string]") {
   }
 
   SECTION("Unicode content") {
-    constexpr const FixedString<32> str1("Привет");
-    constexpr const FixedString<32> str2("Мир");
-    constexpr const FixedString<32> str3("Привет");
+    constexpr FixedString<32> str1("Привет");
+    constexpr FixedString<32> str2("Мир");
+    constexpr FixedString<32> str3("Привет");
 
     REQUIRE(str1 == "Привет");
     REQUIRE("Привет" == str1);
@@ -7726,9 +7771,9 @@ TEST_CASE("FixedString operator==", "[core][fixed_string]") {
   }
 
   SECTION("Performance test") {
-    constexpr const FixedString<64> str1("This is a longer string for performance testing");
-    constexpr const FixedString<64> str2("This is a longer string for performance testing");
-    constexpr const FixedString<64> str3("This is a different string for performance testing");
+    constexpr FixedString<64> str1("This is a longer string for performance testing");
+    constexpr FixedString<64> str2("This is a longer string for performance testing");
+    constexpr FixedString<64> str3("This is a different string for performance testing");
 
     REQUIRE(str1 == str2);
     REQUIRE(str2 == str1);
@@ -7742,9 +7787,9 @@ TEST_CASE("FixedString operator==", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr operations") {
-    constexpr const FixedString<16> str1("Test");
-    constexpr const FixedString<16> str2("Test");
-    constexpr const FixedString<16> str3("Different");
+    constexpr FixedString<16> str1("Test");
+    constexpr FixedString<16> str2("Test");
+    constexpr FixedString<16> str3("Different");
 
     constexpr bool eq1 = str1 == str2;
     constexpr bool eq2 = str1 == str3;
@@ -7771,12 +7816,12 @@ TEST_CASE("FixedString operator==", "[core][fixed_string]") {
 
 TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   SECTION("FixedString <=> FixedString") {
-    constexpr const FixedString<16> str1("Hello");
-    constexpr const FixedString<32> str2("Hello");
-    constexpr const FixedString<16> str3("World");
-    constexpr const FixedString<8> str4("Hello");
-    constexpr const FixedString<16> str5("Hi");
-    constexpr const FixedString<16> str6("Hell");
+    constexpr FixedString<16> str1("Hello");
+    constexpr FixedString<32> str2("Hello");
+    constexpr FixedString<16> str3("World");
+    constexpr FixedString<8> str4("Hello");
+    constexpr FixedString<16> str5("Hi");
+    constexpr FixedString<16> str6("Hell");
 
     // Equal strings
     REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
@@ -7806,7 +7851,7 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("FixedString <=> StringLike") {
-    constexpr const FixedString<16> str1("Hello");
+    constexpr FixedString<16> str1("Hello");
     const std::string str2("Hello");
     const std::string str3("World");
 
@@ -7820,11 +7865,11 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("FixedString <=> C string") {
-    constexpr const FixedString<16> str1("Hello");
-    constexpr const char * str2 = "Hello";
-    constexpr const char * str3 = "World";
-    constexpr const char * str4 = "Hi";
-    constexpr const char * str5 = "Hell";
+    constexpr FixedString<16> str1("Hello");
+    constexpr char * str2 = "Hello";
+    constexpr char * str3 = "World";
+    constexpr char * str4 = "Hi";
+    constexpr char * str5 = "Hell";
 
     // Equal strings
     REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
@@ -7851,11 +7896,11 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("Empty string comparisons") {
-    constexpr const FixedString<16> empty1("");
-    constexpr const FixedString<32> empty2("");
-    constexpr const FixedString<16> nonEmpty("Test");
-    constexpr const char * emptyCStr = "";
-    constexpr const char * nonEmptyCStr = "Test";
+    constexpr FixedString<16> empty1("");
+    constexpr FixedString<32> empty2("");
+    constexpr FixedString<16> nonEmpty("Test");
+    constexpr char * emptyCStr = "";
+    constexpr char * nonEmptyCStr = "Test";
 
     // Empty vs empty
     REQUIRE((empty1 <=> empty2) == std::strong_ordering::equal);
@@ -7881,10 +7926,10 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("Single character strings") {
-    constexpr const FixedString<8> str1("A");
-    constexpr const FixedString<8> str2("B");
-    constexpr const FixedString<8> str3("A");
-    constexpr const FixedString<8> str4("Z");
+    constexpr FixedString<8> str1("A");
+    constexpr FixedString<8> str2("B");
+    constexpr FixedString<8> str3("A");
+    constexpr FixedString<8> str4("Z");
 
     // Equal single characters
     REQUIRE((str1 <=> str3) == std::strong_ordering::equal);
@@ -7910,9 +7955,9 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("Case sensitivity") {
-    constexpr const FixedString<16> lower("hello");
-    constexpr const FixedString<16> upper("HELLO");
-    constexpr const FixedString<16> mixed("Hello");
+    constexpr FixedString<16> lower("hello");
+    constexpr FixedString<16> upper("HELLO");
+    constexpr FixedString<16> mixed("Hello");
 
     // Case-sensitive comparisons
     REQUIRE((lower <=> upper) == std::strong_ordering::greater); // 'h' > 'H' in ASCII
@@ -7931,10 +7976,10 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("Prefix comparisons") {
-    constexpr const FixedString<16> str1("Hello");
-    constexpr const FixedString<16> str2("HelloWorld");
-    constexpr const FixedString<16> str3("Hell");
-    constexpr const FixedString<16> str4("Hello");
+    constexpr FixedString<16> str1("Hello");
+    constexpr FixedString<16> str2("HelloWorld");
+    constexpr FixedString<16> str3("Hell");
+    constexpr FixedString<16> str4("Hello");
 
     // One string is prefix of another
     REQUIRE((str1 <=> str2) == std::strong_ordering::less); // "Hello" < "HelloWorld"
@@ -7956,10 +8001,10 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("Special characters") {
-    constexpr const FixedString<32> str1("Hello\nWorld");
-    constexpr const FixedString<32> str2("Hello\tWorld");
-    constexpr const FixedString<32> str3("Hello World");
-    constexpr const FixedString<32> str4("Hello\nWorld");
+    constexpr FixedString<32> str1("Hello\nWorld");
+    constexpr FixedString<32> str2("Hello\tWorld");
+    constexpr FixedString<32> str3("Hello World");
+    constexpr FixedString<32> str4("Hello\nWorld");
 
     // Equal strings with special characters
     REQUIRE((str1 <=> str4) == std::strong_ordering::equal);
@@ -7985,10 +8030,10 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("Unicode content") {
-    constexpr const FixedString<32> str1("Привет");
-    constexpr const FixedString<32> str2("Мир");
-    constexpr const FixedString<32> str3("Привет");
-    constexpr const FixedString<32> str4("Hello 🌍");
+    constexpr FixedString<32> str1("Привет");
+    constexpr FixedString<32> str2("Мир");
+    constexpr FixedString<32> str3("Привет");
+    constexpr FixedString<32> str4("Hello 🌍");
 
     // Equal Unicode strings
     REQUIRE((str1 <=> str3) == std::strong_ordering::equal);
@@ -8010,11 +8055,11 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("Numeric strings") {
-    constexpr const FixedString<16> str1("123");
-    constexpr const FixedString<16> str2("456");
-    constexpr const FixedString<16> str3("123");
-    constexpr const FixedString<16> str4("12");
-    constexpr const FixedString<16> str5("1234");
+    constexpr FixedString<16> str1("123");
+    constexpr FixedString<16> str2("456");
+    constexpr FixedString<16> str3("123");
+    constexpr FixedString<16> str4("12");
+    constexpr FixedString<16> str5("1234");
 
     // Equal numeric strings
     REQUIRE((str1 <=> str3) == std::strong_ordering::equal);
@@ -8040,9 +8085,9 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("Edge cases") {
-    constexpr const FixedString<4> str1("ABC"); // Maximum length for capacity 4
-    constexpr const FixedString<8> str2("ABC");
-    constexpr const FixedString<16> str3("ABCD");
+    constexpr FixedString<4> str1("ABC"); // Maximum length for capacity 4
+    constexpr FixedString<8> str2("ABC");
+    constexpr FixedString<16> str3("ABCD");
 
     // Same content, different capacities
     REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
@@ -8060,12 +8105,12 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("Constexpr operations") {
-    constexpr const FixedString<16> str1("Test");
-    constexpr const FixedString<16> str2("Test");
-    constexpr const FixedString<16> str3("Different");
-    constexpr const FixedString<16> str4("Test");
-    constexpr const char * str5 = "Test";
-    constexpr const char * str6 = "Different";
+    constexpr FixedString<16> str1("Test");
+    constexpr FixedString<16> str2("Test");
+    constexpr FixedString<16> str3("Different");
+    constexpr FixedString<16> str4("Test");
+    constexpr char * str5 = "Test";
+    constexpr char * str6 = "Different";
 
     constexpr auto eq1 = str1 <=> str2;
     constexpr auto eq2 = str1 <=> str3;
@@ -8091,10 +8136,10 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("Performance test") {
-    constexpr const FixedString<64> str1("This is a very long string for performance testing");
-    constexpr const FixedString<64> str2("This is a very long string for performance testing");
-    constexpr const FixedString<64> str3("This is a very long string for performance testing!");
-    constexpr const FixedString<64> str4("This is a different string for performance testing");
+    constexpr FixedString<64> str1("This is a very long string for performance testing");
+    constexpr FixedString<64> str2("This is a very long string for performance testing");
+    constexpr FixedString<64> str3("This is a very long string for performance testing!");
+    constexpr FixedString<64> str4("This is a different string for performance testing");
 
     // Equal long strings
     REQUIRE((str1 <=> str2) == std::strong_ordering::equal);

--- a/test/core/fix_string_test.cpp
+++ b/test/core/fix_string_test.cpp
@@ -7866,10 +7866,10 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
 
   SECTION("FixedString <=> C string") {
     constexpr FixedString<16> str1("Hello");
-    constexpr char * str2 = "Hello";
-    constexpr char * str3 = "World";
-    constexpr char * str4 = "Hi";
-    constexpr char * str5 = "Hell";
+    constexpr const char * str2 = "Hello";
+    constexpr const char * str3 = "World";
+    constexpr const char * str4 = "Hi";
+    constexpr const char * str5 = "Hell";
 
     // Equal strings
     REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
@@ -7899,8 +7899,8 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
     constexpr FixedString<16> empty1("");
     constexpr FixedString<32> empty2("");
     constexpr FixedString<16> nonEmpty("Test");
-    constexpr char * emptyCStr = "";
-    constexpr char * nonEmptyCStr = "Test";
+    constexpr const char * emptyCStr = "";
+    constexpr const char * nonEmptyCStr = "Test";
 
     // Empty vs empty
     REQUIRE((empty1 <=> empty2) == std::strong_ordering::equal);
@@ -8109,8 +8109,8 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
     constexpr FixedString<16> str2("Test");
     constexpr FixedString<16> str3("Different");
     constexpr FixedString<16> str4("Test");
-    constexpr char * str5 = "Test";
-    constexpr char * str6 = "Different";
+    constexpr const char * str5 = "Test";
+    constexpr const char * str6 = "Different";
 
     constexpr auto eq1 = str1 <=> str2;
     constexpr auto eq2 = str1 <=> str3;

--- a/test/core/fix_string_test.cpp
+++ b/test/core/fix_string_test.cpp
@@ -3983,227 +3983,299 @@ TEST_CASE("FixedString operators+=", "[core][fixed_string]") {
   }
 }
 
-// to refactor 5807 - 3986 = 1821
-
 TEST_CASE("FixedString replace", "[core][fixed_string]") {
   SECTION("Replace with FixedString") {
     FixedString<32> testString("Hello World");
 
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
     testString.replace(6, 5, FixedString<16>("Universe"));
 
-    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe") == 0);
     REQUIRE(testString.size() == 14);
-  }
-
-  SECTION("Replace with string-like object") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(6, 5, std::string("Universe"));
-
     REQUIRE(std::strcmp(testString.c_str(), "Hello Universe") == 0);
-    REQUIRE(testString.size() == 14);
-  }
-
-  SECTION("Replace with C string") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(6, 5, "Universe");
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe") == 0);
-    REQUIRE(testString.size() == 14);
-  }
-
-  SECTION("Replace with repeated characters") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(6, 5, '*', 3);
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hello ***") == 0);
-    REQUIRE(testString.size() == 9);
-  }
-
-  SECTION("Replace at beginning") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(0, 5, "Hi");
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hi World") == 0);
-    REQUIRE(testString.size() == 8);
-  }
-
-  SECTION("Replace at end") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(6, 5, "Universe!");
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe!") == 0);
-    REQUIRE(testString.size() == 15);
-  }
-
-  SECTION("Replace with empty string") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(5, 1, "");
-
-    REQUIRE(std::strcmp(testString.c_str(), "HelloWorld") == 0);
-    REQUIRE(testString.size() == 10);
-  }
-
-  SECTION("Replace with longer string") {
-    FixedString<32> testString("Hi");
-
-    testString.replace(0, 2, "Hello World");
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
-    REQUIRE(testString.size() == 11);
-  }
-
-  SECTION("Replace with shorter string") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(0, 5, "Hi");
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hi World") == 0);
-    REQUIRE(testString.size() == 8);
-  }
-
-  SECTION("Replace single character") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(0, 1, "h");
-
-    REQUIRE(std::strcmp(testString.c_str(), "hello World") == 0);
-    REQUIRE(testString.size() == 11);
-  }
-
-  SECTION("Replace multiple characters with single character") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(0, 5, "H");
-
-    REQUIRE(std::strcmp(testString.c_str(), "H World") == 0);
-    REQUIRE(testString.size() == 7);
-  }
-
-  SECTION("Replace with repeated characters at different positions") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(0, 1, '*', 2);
-    testString.replace(8, 2, '#', 3);
-
-    REQUIRE(std::strcmp(testString.c_str(), "**ello W###ld") == 0);
-    REQUIRE(testString.size() == 13);
-  }
-
-  SECTION("Replace entire string") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(0, 11, "Goodbye Universe");
-
-    REQUIRE(std::strcmp(testString.c_str(), "Goodbye Universe") == 0);
-    REQUIRE(testString.size() == 16);
-  }
-
-  SECTION("Replace with zero count") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(6, 0, "Beautiful ");
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hello Beautiful World") == 0);
-    REQUIRE(testString.size() == 21);
-  }
-
-  SECTION("Replace with single character count") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(6, 5, '!', 1);
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hello !") == 0);
-    REQUIRE(testString.size() == 7);
-  }
-
-  SECTION("Replace with multiple character count") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(6, 5, '=', 4);
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hello ====") == 0);
-    REQUIRE(testString.size() == 10);
-  }
-
-  SECTION("Replace with zero character count") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(6, 5, 'X', 0);
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hello ") == 0);
-    REQUIRE(testString.size() == 6);
-  }
-
-  SECTION("Replace middle portion") {
-    FixedString<32> testString("Hello Beautiful World");
-
-    testString.replace(6, 9, "Amazing");
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hello Amazing World") == 0);
-    REQUIRE(testString.size() == 19);
-  }
-
-  SECTION("Replace with same length string") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(0, 5, "Greet");
-
-    REQUIRE(std::strcmp(testString.c_str(), "Greet World") == 0);
-    REQUIRE(testString.size() == 11);
-  }
-
-  SECTION("Replace with FixedString of different capacity") {
-    FixedString<32> testString("Hello World");
-
-    testString.replace(6, 5, FixedString<12>("Universe"));
-
-    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe") == 0);
-    REQUIRE(testString.size() == 14);
   }
 
   SECTION("Replace with std::string") {
     FixedString<32> testString("Hello World");
 
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
     testString.replace(6, 5, std::string("Universe"));
 
-    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe") == 0);
     REQUIRE(testString.size() == 14);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe") == 0);
+  }
+
+  SECTION("Replace with C-string") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(6, 5, "Universe");
+
+    REQUIRE(testString.size() == 14);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe") == 0);
+  }
+
+  SECTION("Replace with repeated characters") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(6, 5, '*', 3);
+
+    REQUIRE(testString.size() == 9);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello ***") == 0);
+  }
+
+  SECTION("Replace at beginning") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(0, 5, "Hi");
+
+    REQUIRE(testString.size() == 8);
+    REQUIRE(std::strcmp(testString.c_str(), "Hi World") == 0);
+  }
+
+  SECTION("Replace at end") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(6, 5, "Universe!");
+
+    REQUIRE(testString.size() == 15);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe!") == 0);
+  }
+
+  SECTION("Replace with empty string") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(5, 1, "");
+
+    REQUIRE(testString.size() == 10);
+    REQUIRE(std::strcmp(testString.c_str(), "HelloWorld") == 0);
+  }
+
+  SECTION("Replace with longer string") {
+    FixedString<32> testString("Hi");
+
+    REQUIRE(testString.size() == 2);
+    REQUIRE(std::strcmp(testString.c_str(), "Hi") == 0);
+
+    testString.replace(0, 2, "Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+  }
+
+  SECTION("Replace with shorter string") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(0, 5, "Hi");
+
+    REQUIRE(testString.size() == 8);
+    REQUIRE(std::strcmp(testString.c_str(), "Hi World") == 0);
+  }
+
+  SECTION("Replace single character") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(0, 1, "h");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "hello World") == 0);
+  }
+
+  SECTION("Replace multiple characters with single character") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(0, 5, "H");
+
+    REQUIRE(testString.size() == 7);
+    REQUIRE(std::strcmp(testString.c_str(), "H World") == 0);
+  }
+
+  SECTION("Replace with repeated characters at different positions") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(0, 1, '*', 2);
+    testString.replace(8, 2, '#', 3);
+
+    REQUIRE(testString.size() == 13);
+    REQUIRE(std::strcmp(testString.c_str(), "**ello W###ld") == 0);
+  }
+
+  SECTION("Replace entire string") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(0, 11, "Goodbye Universe");
+
+    REQUIRE(testString.size() == 16);
+    REQUIRE(std::strcmp(testString.c_str(), "Goodbye Universe") == 0);
+  }
+
+  SECTION("Replace with zero count") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(6, 0, "Beautiful ");
+
+    REQUIRE(testString.size() == 21);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello Beautiful World") == 0);
+  }
+
+  SECTION("Replace with single character count") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(6, 5, '!', 1);
+
+    REQUIRE(testString.size() == 7);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello !") == 0);
+  }
+
+  SECTION("Replace with multiple character count") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(6, 5, '=', 4);
+
+    REQUIRE(testString.size() == 10);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello ====") == 0);
+  }
+
+  SECTION("Replace with zero character count") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(6, 5, 'X', 0);
+
+    REQUIRE(testString.size() == 6);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello ") == 0);
+  }
+
+  SECTION("Replace middle portion") {
+    FixedString<32> testString("Hello Beautiful World");
+
+    REQUIRE(testString.size() == 21);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello Beautiful World") == 0);
+
+    testString.replace(6, 9, "Amazing");
+
+    REQUIRE(testString.size() == 19);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello Amazing World") == 0);
+  }
+
+  SECTION("Replace with same length string") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(0, 5, "Greet");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Greet World") == 0);
+  }
+
+  SECTION("Replace with FixedString of different capacity") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(6, 5, FixedString<12>("Universe"));
+
+    REQUIRE(testString.size() == 14);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe") == 0);
+  }
+
+  SECTION("Replace with std::string") {
+    FixedString<32> testString("Hello World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
+    testString.replace(6, 5, std::string("Universe"));
+
+    REQUIRE(testString.size() == 14);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe") == 0);
   }
 
   SECTION("Replace with array") {
     FixedString<32> testString("Hello World");
     constexpr std::array<char, 9> arr = {'U', 'n', 'i', 'v', 'e', 'r', 's', 'e', '\0'};
 
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
     testString.replace(6, 5, arr.data());
 
-    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe") == 0);
     REQUIRE(testString.size() == 14);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello Universe") == 0);
   }
 
   SECTION("Replace at position 0 with zero count") {
     FixedString<32> testString("Hello World");
 
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
     testString.replace(0, 0, "Hi ");
 
-    REQUIRE(std::strcmp(testString.c_str(), "Hi Hello World") == 0);
     REQUIRE(testString.size() == 14);
+    REQUIRE(std::strcmp(testString.c_str(), "Hi Hello World") == 0);
   }
 
   SECTION("Replace at end with zero count") {
     FixedString<32> testString("Hello World");
 
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+
     testString.replace(11, 0, "!");
 
-    REQUIRE(std::strcmp(testString.c_str(), "Hello World!") == 0);
     REQUIRE(testString.size() == 12);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World!") == 0);
   }
 }
+
+// to refactor 5879 - 4278 = 1601
 
 TEST_CASE("FixedString copy", "[core][fixed_string]") {
   SECTION("Copy entire string") {

--- a/test/core/fix_string_test.cpp
+++ b/test/core/fix_string_test.cpp
@@ -3743,20 +3743,247 @@ TEST_CASE("FixedString append", "[core][fixed_string]") {
   }
 }
 
-// to refactor 5580 - 3746 = 1834
-
 TEST_CASE("FixedString operators+=", "[core][fixed_string]") {
-  FixedString<32> testString("");
+  SECTION("Operator += with FixedString") {
+    FixedString<32> testString("Hello");
 
-  testString += FixedString<16>("Nothing");
-  testString += FixedString<8>(" else");
-  testString += std::string(" really");
-  testString += " matters";
-  testString += '.';
+    REQUIRE(testString.size() == 5);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello") == 0);
 
-  REQUIRE(std::strcmp(testString.c_str(), "Nothing else really matters.") == 0);
-  REQUIRE(testString.size() == 28);
+    testString += FixedString<16>(" World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+  }
+
+  SECTION("Operator += with C-string") {
+    FixedString<32> testString("Hello");
+
+    REQUIRE(testString.size() == 5);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello") == 0);
+
+    testString += " World";
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+  }
+
+  SECTION("Operator += with std::string") {
+    FixedString<32> testString("Hello");
+
+    REQUIRE(testString.size() == 5);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello") == 0);
+
+    testString += std::string(" World");
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World") == 0);
+  }
+
+  SECTION("Operator += with single character") {
+    FixedString<32> testString("Hello");
+
+    REQUIRE(testString.size() == 5);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello") == 0);
+
+    testString += '!';
+
+    REQUIRE(testString.size() == 6);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello!") == 0);
+  }
+
+  SECTION("Operator += to empty string") {
+    FixedString<32> emptyString;
+
+    REQUIRE(emptyString.empty());
+    REQUIRE(emptyString.size() == 0);
+
+    emptyString += "Hello";
+
+    REQUIRE_FALSE(emptyString.empty());
+    REQUIRE(emptyString.size() == 5);
+    REQUIRE(std::strcmp(emptyString.c_str(), "Hello") == 0);
+  }
+
+  SECTION("Operator += with special characters") {
+    FixedString<32> testString("Hello");
+
+    REQUIRE(testString.size() == 5);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello") == 0);
+
+    testString += '\n';
+    testString += '\t';
+    testString += '!';
+
+    REQUIRE(testString.size() == 8);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello\n\t!") == 0);
+  }
+
+  SECTION("Operator += with Unicode content") {
+    FixedString<64> testString("Hello");
+
+    REQUIRE(testString.size() == 5);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello") == 0);
+
+    testString += " 世界";
+
+    REQUIRE(testString.size() == 12);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello 世界") == 0);
+  }
+
+  SECTION("Operator += with different capacities") {
+    FixedString<8> smallString("Hi");
+    FixedString<16> mediumString("Hello");
+    FixedString<32> largeString("Hello World");
+
+    smallString += "!";
+    mediumString += " World";
+    largeString += "!";
+
+    REQUIRE(std::strcmp(smallString.c_str(), "Hi!") == 0);
+    REQUIRE(std::strcmp(mediumString.c_str(), "Hello World") == 0);
+    REQUIRE(std::strcmp(largeString.c_str(), "Hello World!") == 0);
+
+    REQUIRE(smallString.size() == 3);
+    REQUIRE(mediumString.size() == 11);
+    REQUIRE(largeString.size() == 12);
+  }
+
+  SECTION("Operator += numeric content") {
+    FixedString<16> testString("123");
+
+    REQUIRE(testString.size() == 3);
+    REQUIRE(std::strcmp(testString.c_str(), "123") == 0);
+
+    testString += "456";
+
+    REQUIRE(testString.size() == 6);
+    REQUIRE(std::strcmp(testString.c_str(), "123456") == 0);
+  }
+
+  SECTION("Operator += mixed content") {
+    FixedString<32> testString("Test");
+
+    REQUIRE(testString.size() == 4);
+    REQUIRE(std::strcmp(testString.c_str(), "Test") == 0);
+
+    testString += " 123!";
+
+    REQUIRE(testString.size() == 9);
+    REQUIRE(std::strcmp(testString.c_str(), "Test 123!") == 0);
+  }
+
+  SECTION("Operator += edge cases") {
+    FixedString<16> testString("A");
+
+    REQUIRE(testString.size() == 1);
+    REQUIRE(std::strcmp(testString.c_str(), "A") == 0);
+
+    testString += "BC";
+
+    REQUIRE(testString.size() == 3);
+    REQUIRE(std::strcmp(testString.c_str(), "ABC") == 0);
+  }
+
+  SECTION("Operator += and size consistency") {
+    FixedString<16> testString;
+
+    REQUIRE(testString.empty());
+    REQUIRE(testString.size() == 0);
+
+    testString += "A";
+    REQUIRE(testString.size() == 1);
+
+    testString += "B";
+    REQUIRE(testString.size() == 2);
+
+    testString += "C";
+    REQUIRE(testString.size() == 3);
+
+    REQUIRE(std::strcmp(testString.c_str(), "ABC") == 0);
+  }
+
+  SECTION("Operator += chaining") {
+    FixedString<32> testString("");
+
+    REQUIRE(testString.empty());
+    REQUIRE(testString.size() == 0);
+
+    testString += FixedString<16>("Nothing");
+    testString += FixedString<8>(" else");
+    testString += std::string(" really");
+    testString += " matters";
+    testString += '.';
+
+    REQUIRE(testString.size() == 28);
+    REQUIRE(std::strcmp(testString.c_str(), "Nothing else really matters.") == 0);
+  }
+
+  SECTION("Operator += and reassignment") {
+    FixedString<18> testString("Original");
+
+    REQUIRE(testString.size() == 8);
+    REQUIRE(std::strcmp(testString.c_str(), "Original") == 0);
+
+    testString += " content";
+
+    REQUIRE(testString.size() == 16);
+    REQUIRE(std::strcmp(testString.c_str(), "Original content") == 0);
+
+    // Reassign after +=
+    testString = "New";
+
+    REQUIRE(testString.size() == 3);
+    REQUIRE(std::strcmp(testString.c_str(), "New") == 0);
+  }
+
+  SECTION("Operator += with capacity preservation") {
+    FixedString<16> testString("Hello");
+
+    const auto originalCapacity = testString.capacity();
+    const auto originalMaxSize = testString.max_size();
+
+    REQUIRE(testString.size() == 5);
+
+    testString += " World";
+
+    REQUIRE(testString.size() == 11);
+    REQUIRE(testString.capacity() == originalCapacity);
+    REQUIRE(testString.max_size() == originalMaxSize);
+  }
+
+  SECTION("Operator += with different types") {
+    FixedString<32> testString("Hello");
+
+    REQUIRE(testString.size() == 5);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello") == 0);
+
+    testString += FixedString<8>(" ");
+    testString += "World";
+    testString += std::string("!");
+    testString += ' ';
+    testString += '2';
+
+    REQUIRE(testString.size() == 14);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello World! 2") == 0);
+  }
+
+  SECTION("Operator += with empty operands") {
+    FixedString<16> testString("Hello");
+
+    REQUIRE(testString.size() == 5);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello") == 0);
+
+    testString += FixedString<8>("");
+    testString += "";
+    testString += std::string("");
+
+    REQUIRE(testString.size() == 5);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello") == 0);
+  }
 }
+
+// to refactor 5807 - 3986 = 1821
 
 TEST_CASE("FixedString replace", "[core][fixed_string]") {
   SECTION("Replace with FixedString") {


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Remove redundant `const` qualifiers from `constexpr` variable declarations

- Update copy constructor and assignment operator to use `= default`

- Improve documentation comments for clarity and consistency

- Clean up terminology from "C-style string" to "C string"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["constexpr const CStringView"] --> B["constexpr CStringView"]
  C["Custom copy constructor"] --> D["= default copy constructor"]
  E["C-style string docs"] --> F["C string docs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>c_string_view_test.cpp</strong><dd><code>Remove redundant const qualifiers from tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/core/c_string_view_test.cpp

<ul><li>Remove redundant <code>const</code> qualifiers from <code>constexpr CStringView</code> <br>declarations<br> <li> Simplify variable declarations throughout all test cases<br> <li> Maintain same test functionality with cleaner syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/111/files#diff-2e6a5805b82d6df486ae0d658f5172c7ba8c1a58847a5bb3d7b57e6167c37188">+183/-183</a></td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>c_string_view.hpp</strong><dd><code>Modernize constructors and improve documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/core/c_string_view.hpp

<ul><li>Mark copy constructor and assignment operator as <code>= default</code><br> <li> Update documentation comments for consistency<br> <li> Change "C-style string" terminology to "C string"<br> <li> Improve comment clarity in private member documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/111/files#diff-9d334ca7b15ac828f1536b20c0fcfd89f80a8970841385b4b869e2dd4ae26849">+15/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

