### PR TITLE
119 cstringview non member functions

### DIFF
--- a/include/core/c_string_view.hpp
+++ b/include/core/c_string_view.hpp
@@ -978,6 +978,101 @@ private:
                                               std::size_t dataSize) const noexcept;
 };
 
+/*!
+  \brief Equality comparison operator for two CStringView objects.
+
+  This operator compares two CStringView objects for equality. The comparison is performed character by character.
+
+  \param lhs The left-hand side CStringView object.
+  \param rhs The right-hand side CStringView object.
+
+  \return True if both strings view have the same content, false otherwise.
+
+  \note The comparison is case-sensitive.
+  \note Empty string views are considered equal.
+
+  \see operator<=>(const CStringView &, const CStringView &)
+*/
+[[nodiscard]] constexpr bool operator==(const CStringView & lhs, const CStringView & rhs) noexcept;
+
+/*!
+  \brief Equality comparison operator for CStringView and StringLike object.
+
+  This operator compares a CStringView object with a StringLike object for equality.
+
+  \tparam stringType The type of the StringLike object. Must satisfy the StringLike concept.
+
+  \param lhs The CStringView object.
+  \param rhs The StringLike object.
+
+  \return True if both strings have the same content, false otherwise.
+
+  \note The comparison is case-sensitive.
+  \note Empty strings are considered equal.
+
+  \see operator<=>(const CStringView &, const stringType &)
+*/
+template <StringLike stringType>
+[[nodiscard]] constexpr bool operator==(const CStringView & lhs, const stringType & rhs) noexcept;
+
+/*!
+  \brief Equality comparison operator for StringLike object and CStringView.
+
+  This operator compares a StringLike object with a CStringView object for equality.
+
+  \tparam stringType The type of the StringLike object. Must satisfy the StringLike concept.
+
+  \param lhs The StringLike object.
+  \param rhs The CStringView object.
+
+  \return True if both strings have the same content, false otherwise.
+
+  \note The comparison is case-sensitive.
+  \note Empty strings are considered equal.
+
+  \see operator<=>(const stringType &, const CStringView &)
+*/
+template <StringLike stringType>
+[[nodiscard]] constexpr bool operator==(const stringType & lhs, const CStringView & rhs) noexcept;
+
+/*!
+  \brief Equality comparison operator for CStringView and C string.
+
+  This operator compares a CStringView object with a C string for equality.
+
+  \param lhs The CStringView object.
+  \param rhs The C string.
+
+  \return True if both strings have the same content, false otherwise.
+
+  \pre The \a rhs pointer must not be null.
+
+  \note The comparison is case-sensitive.
+  \note Empty strings are considered equal.
+
+  \see operator<=>(const CStringView &, const char *)
+*/
+[[nodiscard]] constexpr bool operator==(const CStringView & lhs, const char * rhs) noexcept;
+
+/*!
+  \brief Equality comparison operator for C string and CStringView.
+
+  This operator compares a C string with a CStringView object for equality.
+
+  \param lhs The C string.
+  \param rhs The CStringView object.
+
+  \return True if both strings have the same content, false otherwise.
+
+  \pre The \a lhs pointer must not be null.
+
+  \note The comparison is case-sensitive.
+  \note Empty strings are considered equal.
+
+  \see operator<=>(const char *, const CStringView &)
+*/
+[[nodiscard]] constexpr bool operator==(const char * lhs, const CStringView & rhs) noexcept;
+
 } // namespace toy
 
 #endif // INCLUDE_CORE_C_STRING_VIEW_HPP_

--- a/include/core/c_string_view.hpp
+++ b/include/core/c_string_view.hpp
@@ -1073,6 +1073,121 @@ template <StringLike stringType>
 */
 [[nodiscard]] constexpr bool operator==(const char * lhs, const CStringView & rhs) noexcept;
 
+/*!
+  \brief Three-way comparison operator for CStringView objects.
+
+  This operator provides a three-way comparison between two CStringView objects. It returns a std::strong_ordering value
+  that indicates the relationship between the string views.
+
+  \param lhs The left-hand side CStringView object to compare.
+  \param rhs The right-hand side CStringView object to compare.
+
+  \return std::strong_ordering::less if \a lhs is lexicographically less than \a rhs, std::strong_ordering::equal if
+          they are equal, or std::strong_ordering::greater if \a lhs is lexicographically greater than \a rhs.
+
+  \note The comparison is case-sensitive.
+  \note The comparison is performed lexicographically character by character.
+  \note Empty string views are considered equal.
+
+  \see std::strong_ordering
+  \see operator==(const CStringView &, const CStringView &)
+*/
+[[nodiscard]] constexpr std::strong_ordering operator<=>(const CStringView & lhs, const CStringView & rhs) noexcept;
+
+/*!
+  \brief Three-way comparison operator for CStringView and StringLike object.
+
+  This operator provides a three-way comparison between a CStringView object and a StringLike object. It returns a
+  std::strong_ordering value that indicates the relationship between the strings.
+
+  \tparam stringType The type of the StringLike object. Must satisfy the StringLike concept.
+
+  \param lhs The CStringView object to compare.
+  \param rhs The StringLike object to compare.
+
+  \return std::strong_ordering::less if \a lhs is lexicographically less than \a rhs, std::strong_ordering::equal if
+          they are equal, or std::strong_ordering::greater if \a lhs is lexicographically greater than \a rhs.
+
+  \note The comparison is case-sensitive.
+  \note The comparison is performed lexicographically character by character.
+  \note Empty strings are considered equal.
+
+  \see std::strong_ordering
+  \see operator==(const CStringView &, const stringType &)
+*/
+template <StringLike stringType>
+[[nodiscard]] constexpr std::strong_ordering operator<=>(const CStringView & lhs, const stringType & rhs) noexcept;
+
+/*!
+  \brief Three-way comparison operator for StringLike object and CStringView.
+
+  This operator provides a three-way comparison between a StringLike object and a CStringView object. It returns a
+  std::strong_ordering value that indicates the relationship between the strings.
+
+  \tparam stringType The type of the StringLike object. Must satisfy the StringLike concept.
+
+  \param lhs The StringLike object to compare.
+  \param rhs The CStringView object to compare.
+
+  \return std::strong_ordering::less if \a lhs is lexicographically less than \a rhs, std::strong_ordering::equal if
+          they are equal, or std::strong_ordering::greater if \a lhs is lexicographically greater than \a rhs.
+
+  \note The comparison is case-sensitive.
+  \note The comparison is performed lexicographically character by character.
+  \note Empty strings are considered equal.
+
+  \see std::strong_ordering
+  \see operator==(const stringType &, const CStringView &)
+*/
+template <StringLike stringType>
+[[nodiscard]] constexpr std::strong_ordering operator<=>(const stringType & lhs, const CStringView & rhs) noexcept;
+
+/*!
+  \brief Three-way comparison operator for CStringView and C string.
+
+  This operator provides a three-way comparison between a CStringView object and a C string. It returns a
+  std::strong_ordering value that indicates the relationship between the strings.
+
+  \param lhs The CStringView object to compare.
+  \param rhs The C string to compare.
+
+  \return std::strong_ordering::less if \a lhs is lexicographically less than \a rhs, std::strong_ordering::equal if
+          they are equal, or std::strong_ordering::greater if \a lhs is lexicographically greater than \a rhs.
+
+  \pre The \a rhs pointer must not be null.
+
+  \note The comparison is case-sensitive.
+  \note The comparison is performed lexicographically character by character.
+  \note Empty strings are considered equal.
+
+  \see std::strong_ordering
+  \see operator==(const CStringView &, const char *)
+*/
+[[nodiscard]] constexpr std::strong_ordering operator<=>(const CStringView & lhs, const char * rhs) noexcept;
+
+/*!
+  \brief Three-way comparison operator for C string and CStringView.
+
+  This operator provides a three-way comparison between a C string and a CStringView object. It returns a
+  std::strong_ordering value that indicates the relationship between the strings.
+
+  \param lhs The C string to compare.
+  \param rhs The CStringView object to compare.
+
+  \return std::strong_ordering::less if \a lhs is lexicographically less than \a rhs, std::strong_ordering::equal if
+          they are equal, or std::strong_ordering::greater if \a lhs is lexicographically greater than \a rhs.
+
+  \pre The \a lhs pointer must not be null.
+
+  \note The comparison is case-sensitive.
+  \note The comparison is performed lexicographically character by character.
+  \note Empty strings are considered equal.
+
+  \see std::strong_ordering
+  \see operator==(const char *, const CStringView &)
+*/
+[[nodiscard]] constexpr std::strong_ordering operator<=>(const char * lhs, const CStringView & rhs) noexcept;
+
 } // namespace toy
 
 #endif // INCLUDE_CORE_C_STRING_VIEW_HPP_

--- a/include/core/c_string_view.inl
+++ b/include/core/c_string_view.inl
@@ -482,11 +482,11 @@ constexpr bool operator==(const CStringView & lhs, const CStringView & rhs) noex
 
 template <StringLike stringType>
 constexpr bool operator==(const CStringView & lhs, const stringType & rhs) noexcept {
-  if (lhs.c_str() == rhs.c_str() || (lhs.empty() && rhs.empty()))
+  if (lhs.c_str() == rhs.c_str() || (lhs.empty() && rhs.size() == 0))
     return true;
 
   if consteval {
-    return cstrcmp(lhs.c_str(), rhs.c_str());
+    return cstrcmp(lhs.c_str(), rhs.c_str()) == 0;
   } else {
     return std::strcmp(lhs.c_str(), rhs.c_str()) == 0;
   }

--- a/include/core/c_string_view.inl
+++ b/include/core/c_string_view.inl
@@ -517,21 +517,9 @@ constexpr std::strong_ordering operator<=>(const CStringView & lhs, const CStrin
     return std::strong_ordering::greater;
 
   if consteval {
-    const int result = cstrcmp(lhs.c_str(), rhs.c_str());
-    if (result < 0)
-      return std::strong_ordering::less;
-    else if (result > 0)
-      return std::strong_ordering::greater;
-    else
-      return std::strong_ordering::equal;
+    return cstrcmp(lhs.c_str(), rhs.c_str()) <=> 0;
   } else {
-    const int result = std::strcmp(lhs.c_str(), rhs.c_str());
-    if (result < 0)
-      return std::strong_ordering::less;
-    else if (result > 0)
-      return std::strong_ordering::greater;
-    else
-      return std::strong_ordering::equal;
+    return std::strcmp(lhs.c_str(), rhs.c_str()) <=> 0;
   }
 }
 
@@ -545,21 +533,9 @@ constexpr std::strong_ordering operator<=>(const CStringView & lhs, const string
     return std::strong_ordering::greater;
 
   if consteval {
-    const int result = cstrcmp(lhs.c_str(), rhs.c_str());
-    if (result < 0)
-      return std::strong_ordering::less;
-    else if (result > 0)
-      return std::strong_ordering::greater;
-    else
-      return std::strong_ordering::equal;
+    return cstrcmp(lhs.c_str(), rhs.c_str()) <=> 0;
   } else {
-    const int result = std::strcmp(lhs.c_str(), rhs.c_str());
-    if (result < 0)
-      return std::strong_ordering::less;
-    else if (result > 0)
-      return std::strong_ordering::greater;
-    else
-      return std::strong_ordering::equal;
+    return std::strcmp(lhs.c_str(), rhs.c_str()) <=> 0;
   }
 }
 

--- a/include/core/c_string_view.inl
+++ b/include/core/c_string_view.inl
@@ -469,6 +469,42 @@ constexpr std::size_t CStringView::_find_last_not_of_raw(std::size_t position, c
   return npos;
 }
 
+constexpr bool operator==(const CStringView & lhs, const CStringView & rhs) noexcept {
+  if (std::addressof(lhs) == std::addressof(rhs) || (lhs.empty() && rhs.empty()))
+    return true;
+
+  if consteval {
+    return cstrcmp(lhs.c_str(), rhs.c_str()) == 0;
+  } else {
+    return std::strcmp(lhs.c_str(), rhs.c_str()) == 0;
+  }
+}
+
+template <StringLike stringType>
+constexpr bool operator==(const CStringView & lhs, const stringType & rhs) noexcept {
+  if (lhs.c_str() == rhs.c_str() || (lhs.empty() && rhs.empty()))
+    return true;
+
+  if consteval {
+    return cstrcmp(lhs.c_str(), rhs.c_str());
+  } else {
+    return std::strcmp(lhs.c_str(), rhs.c_str()) == 0;
+  }
+}
+
+template <StringLike stringType>
+constexpr bool operator==(const stringType & lhs, const CStringView & rhs) noexcept {
+  return rhs == lhs;
+}
+
+constexpr bool operator==(const CStringView & lhs, const char * rhs) noexcept {
+  return lhs == CStringView(rhs);
+}
+
+constexpr bool operator==(const char * lhs, const CStringView & rhs) noexcept {
+  return CStringView(lhs) == rhs;
+}
+
 } // namespace toy
 
 #endif // INCLUDE_CORE_C_STRING_VIEW_INL_

--- a/include/core/c_string_view.inl
+++ b/include/core/c_string_view.inl
@@ -505,6 +505,83 @@ constexpr bool operator==(const char * lhs, const CStringView & rhs) noexcept {
   return CStringView(lhs) == rhs;
 }
 
+constexpr std::strong_ordering operator<=>(const CStringView & lhs, const CStringView & rhs) noexcept {
+  if (std::addressof(lhs) == std::addressof(rhs))
+    return std::strong_ordering::equal;
+
+  if (lhs.empty() && rhs.empty())
+    return std::strong_ordering::equal;
+  else if (lhs.empty())
+    return std::strong_ordering::less;
+  else if (rhs.empty())
+    return std::strong_ordering::greater;
+
+  if consteval {
+    const int result = cstrcmp(lhs.c_str(), rhs.c_str());
+    if (result < 0)
+      return std::strong_ordering::less;
+    else if (result > 0)
+      return std::strong_ordering::greater;
+    else
+      return std::strong_ordering::equal;
+  } else {
+    const int result = std::strcmp(lhs.c_str(), rhs.c_str());
+    if (result < 0)
+      return std::strong_ordering::less;
+    else if (result > 0)
+      return std::strong_ordering::greater;
+    else
+      return std::strong_ordering::equal;
+  }
+}
+
+template <StringLike stringType>
+constexpr std::strong_ordering operator<=>(const CStringView & lhs, const stringType & rhs) noexcept {
+  if (lhs.empty() && rhs.size() == 0)
+    return std::strong_ordering::equal;
+  else if (lhs.empty())
+    return std::strong_ordering::less;
+  else if (rhs.size() == 0)
+    return std::strong_ordering::greater;
+
+  if consteval {
+    const int result = cstrcmp(lhs.c_str(), rhs.c_str());
+    if (result < 0)
+      return std::strong_ordering::less;
+    else if (result > 0)
+      return std::strong_ordering::greater;
+    else
+      return std::strong_ordering::equal;
+  } else {
+    const int result = std::strcmp(lhs.c_str(), rhs.c_str());
+    if (result < 0)
+      return std::strong_ordering::less;
+    else if (result > 0)
+      return std::strong_ordering::greater;
+    else
+      return std::strong_ordering::equal;
+  }
+}
+
+template <StringLike stringType>
+constexpr std::strong_ordering operator<=>(const stringType & lhs, const CStringView & rhs) noexcept {
+  const auto result = rhs <=> lhs;
+  if (result == std::strong_ordering::less)
+    return std::strong_ordering::greater;
+  else if (result == std::strong_ordering::greater)
+    return std::strong_ordering::less;
+  else
+    return std::strong_ordering::equal;
+}
+
+constexpr std::strong_ordering operator<=>(const CStringView & lhs, const char * rhs) noexcept {
+  return lhs <=> CStringView(rhs);
+}
+
+constexpr std::strong_ordering operator<=>(const char * lhs, const CStringView & rhs) noexcept {
+  return CStringView(lhs) <=> rhs;
+}
+
 } // namespace toy
 
 #endif // INCLUDE_CORE_C_STRING_VIEW_INL_

--- a/include/core/c_string_view.inl
+++ b/include/core/c_string_view.inl
@@ -498,10 +498,14 @@ constexpr bool operator==(const stringType & lhs, const CStringView & rhs) noexc
 }
 
 constexpr bool operator==(const CStringView & lhs, const char * rhs) noexcept {
+  assert_message(rhs != nullptr, "String pointer must not be null");
+
   return lhs == CStringView(rhs);
 }
 
 constexpr bool operator==(const char * lhs, const CStringView & rhs) noexcept {
+  assert_message(lhs != nullptr, "String pointer must not be null");
+
   return CStringView(lhs) == rhs;
 }
 

--- a/include/core/fixed_string.inl
+++ b/include/core/fixed_string.inl
@@ -1445,13 +1445,7 @@ constexpr std::strong_ordering operator<=>(const FixedString<allocatedSize1> & l
     return std::strong_ordering::greater;
 
   if consteval {
-    const int result = cstrcmp(lhs.c_str(), rhs.c_str());
-    if (result < 0)
-      return std::strong_ordering::less;
-    else if (result > 0)
-      return std::strong_ordering::greater;
-    else
-      return std::strong_ordering::equal;
+    return cstrcmp(lhs.c_str(), rhs.c_str()) <=> 0;
   } else {
     const int result = std::memcmp(lhs.c_str(), rhs.c_str(), std::min(lhs.size(), rhs.size()));
     if (result < 0)
@@ -1479,13 +1473,7 @@ constexpr std::strong_ordering operator<=>(const FixedString<allocatedSize> & lh
     return std::strong_ordering::greater;
 
   if consteval {
-    const int result = cstrcmp(lhs.c_str(), rhs.c_str());
-    if (result < 0)
-      return std::strong_ordering::less;
-    else if (result > 0)
-      return std::strong_ordering::greater;
-    else
-      return std::strong_ordering::equal;
+    return cstrcmp(lhs.c_str(), rhs.c_str()) <=> 0;
   } else {
     const int result = std::memcmp(lhs.c_str(), rhs.c_str(), std::min(lhs.size(), rhs.size()));
     if (result < 0)

--- a/include/core/fixed_string.inl
+++ b/include/core/fixed_string.inl
@@ -1514,13 +1514,7 @@ constexpr std::strong_ordering operator<=>(const FixedString<allocatedSize> & lh
     return std::strong_ordering::greater;
 
   if consteval {
-    const int result = cstrcmp(lhs.c_str(), rhs);
-    if (result < 0)
-      return std::strong_ordering::less;
-    else if (result > 0)
-      return std::strong_ordering::greater;
-    else
-      return std::strong_ordering::equal;
+    return cstrcmp(lhs.c_str(), rhs) <=> 0;
   } else {
     const auto rhsLen = std::strlen(rhs);
     const int result = std::memcmp(lhs.c_str(), rhs, std::min(lhs.size(), rhsLen));

--- a/test/core/c_string_view_test.cpp
+++ b/test/core/c_string_view_test.cpp
@@ -5257,3 +5257,149 @@ TEST_CASE("CStringView operator<=>", "[core][c_string_view]") {
     STATIC_REQUIRE((str3 <=> str1) == std::strong_ordering::greater);
   }
 }
+
+TEST_CASE("CStringView std::swap", "[core][c_string_view]") {
+  SECTION("Basic swap functionality") {
+    CStringView str1("Hello");
+    CStringView str2("World");
+
+    std::swap(str1, str2);
+
+    REQUIRE(str1.size() == 5);
+    REQUIRE(std::strcmp(str1.c_str(), "World") == 0);
+    REQUIRE(str2.size() == 5);
+    REQUIRE(std::strcmp(str2.c_str(), "Hello") == 0);
+  }
+
+  SECTION("Swap with empty strings") {
+    CStringView str1("Hello");
+    CStringView str2("");
+
+    std::swap(str1, str2);
+
+    REQUIRE(str1.size() == 0);
+    REQUIRE(std::strcmp(str1.c_str(), "") == 0);
+    REQUIRE(str2.size() == 5);
+    REQUIRE(std::strcmp(str2.c_str(), "Hello") == 0);
+  }
+
+  SECTION("Swap two empty strings") {
+    CStringView str1("");
+    CStringView str2("");
+
+    std::swap(str1, str2);
+
+    REQUIRE(str1.size() == 0);
+    REQUIRE(std::strcmp(str1.c_str(), "") == 0);
+    REQUIRE(str2.size() == 0);
+    REQUIRE(std::strcmp(str2.c_str(), "") == 0);
+  }
+
+  SECTION("Self-swap") {
+    CStringView str1("Hello");
+
+    std::swap(str1, str1);
+
+    REQUIRE(str1.size() == 5);
+    REQUIRE(std::strcmp(str1.c_str(), "Hello") == 0);
+  }
+
+  SECTION("Swap with different sizes") {
+    CStringView str1("Hi");
+    CStringView str2("VeryLongString");
+
+    std::swap(str1, str2);
+
+    REQUIRE(str1.size() == 14);
+    REQUIRE(std::strcmp(str1.c_str(), "VeryLongString") == 0);
+    REQUIRE(str2.size() == 2);
+    REQUIRE(std::strcmp(str2.c_str(), "Hi") == 0);
+  }
+
+  SECTION("Swap with maximum length strings") {
+    CStringView str1("123456789012345"); // 15 chars
+    CStringView str2("ABCDEFGHIJKLMNO"); // 15 chars
+
+    std::swap(str1, str2);
+
+    REQUIRE(str1.size() == 15);
+    REQUIRE(std::strcmp(str1.c_str(), "ABCDEFGHIJKLMNO") == 0);
+    REQUIRE(str2.size() == 15);
+    REQUIRE(std::strcmp(str2.c_str(), "123456789012345") == 0);
+  }
+
+  SECTION("Swap with special characters") {
+    CStringView str1("Hello,\n\t!");
+    CStringView str2("World,\r\n?");
+
+    std::swap(str1, str2);
+
+    REQUIRE(str1.size() == 9);
+    REQUIRE(std::strcmp(str1.c_str(), "World,\r\n?") == 0);
+    REQUIRE(str2.size() == 9);
+    REQUIRE(std::strcmp(str2.c_str(), "Hello,\n\t!") == 0);
+  }
+
+  SECTION("Swap with Unicode content") {
+    CStringView str1("Hello 世界");
+    CStringView str2("World 宇宙");
+
+    std::swap(str1, str2);
+
+    REQUIRE(str1.size() == 12);
+    REQUIRE(std::strcmp(str1.c_str(), "World 宇宙") == 0);
+    REQUIRE(str2.size() == 12);
+    REQUIRE(std::strcmp(str2.c_str(), "Hello 世界") == 0);
+  }
+
+  SECTION("Multiple swaps") {
+    CStringView str1("First");
+    CStringView str2("Second");
+    CStringView str3("Third");
+
+    std::swap(str1, str2);
+
+    REQUIRE(str1.size() == 6);
+    REQUIRE(std::strcmp(str1.c_str(), "Second") == 0);
+    REQUIRE(str2.size() == 5);
+    REQUIRE(std::strcmp(str2.c_str(), "First") == 0);
+
+    std::swap(str2, str3);
+
+    REQUIRE(str2.size() == 5);
+    REQUIRE(std::strcmp(str2.c_str(), "Third") == 0);
+    REQUIRE(str3.size() == 5);
+    REQUIRE(std::strcmp(str3.c_str(), "First") == 0);
+
+    std::swap(str1, str3);
+
+    REQUIRE(str1.size() == 5);
+    REQUIRE(std::strcmp(str1.c_str(), "First") == 0);
+    REQUIRE(str3.size() == 6);
+    REQUIRE(std::strcmp(str3.c_str(), "Second") == 0);
+  }
+
+  SECTION("Performance test with large strings") {
+    CStringView str1("This is a very long string that tests swap performance");
+    CStringView str2("Another very long string for performance testing");
+
+    std::swap(str1, str2);
+
+    REQUIRE(str1.size() == 48);
+    REQUIRE(std::strcmp(str1.c_str(), "Another very long string for performance testing") == 0);
+    REQUIRE(str2.size() == 54);
+    REQUIRE(std::strcmp(str2.c_str(), "This is a very long string that tests swap performance") == 0);
+  }
+
+  SECTION("Swap with single character strings") {
+    CStringView str1("A");
+    CStringView str2("B");
+
+    std::swap(str1, str2);
+
+    REQUIRE(str1.size() == 1);
+    REQUIRE(std::strcmp(str1.c_str(), "B") == 0);
+    REQUIRE(str2.size() == 1);
+    REQUIRE(std::strcmp(str2.c_str(), "A") == 0);
+  }
+}

--- a/test/core/c_string_view_test.cpp
+++ b/test/core/c_string_view_test.cpp
@@ -4734,3 +4734,201 @@ TEST_CASE("CStringView contains", "[core][c_string_view]") {
     STATIC_REQUIRE(str.contains("World") == true);
   }
 }
+
+TEST_CASE("CStringView operator==", "[core][c_string_view]") {
+  SECTION("CStringView == CStringView") {
+    constexpr CStringView str1("Hello");
+    constexpr CStringView str2("Hello");
+    constexpr CStringView str3("World");
+    constexpr CStringView empty1;
+    constexpr CStringView empty2;
+
+    REQUIRE(str1 == str2);
+    REQUIRE(str2 == str1);
+    REQUIRE_FALSE((str1 == str3));
+    REQUIRE_FALSE((str3 == str1));
+    REQUIRE(empty1 == empty2);
+    REQUIRE(empty2 == empty1);
+    REQUIRE_FALSE((str1 == empty1));
+    REQUIRE_FALSE((empty1 == str1));
+
+    // Compile-time checks
+    STATIC_REQUIRE(str1 == str2);
+    STATIC_REQUIRE(str2 == str1);
+    STATIC_REQUIRE_FALSE((str1 == str3));
+    STATIC_REQUIRE_FALSE((str3 == str1));
+    STATIC_REQUIRE(empty1 == empty2);
+    STATIC_REQUIRE(empty2 == empty1);
+    STATIC_REQUIRE_FALSE((str1 == empty1));
+    STATIC_REQUIRE_FALSE((empty1 == str1));
+  }
+
+  SECTION("FixedString == StringLike") {
+    constexpr CStringView str("Hello");
+    const std::string stdStr1;
+    const std::string stdStr2("Hello");
+    const std::string stdStr3("World");
+
+    REQUIRE_FALSE((str == stdStr1));
+    REQUIRE_FALSE((stdStr1 == str));
+    REQUIRE(str == stdStr2);
+    REQUIRE(stdStr2 == str);
+    REQUIRE_FALSE((str == stdStr3));
+    REQUIRE_FALSE((stdStr3 == str));
+  }
+
+  SECTION("CStringView == C string") {
+    constexpr CStringView str1("Hello");
+    constexpr CStringView empty;
+
+    REQUIRE(str1 == "Hello");
+    REQUIRE("Hello" == str1);
+    REQUIRE_FALSE((str1 == "World"));
+    REQUIRE_FALSE(("World" == str1));
+    REQUIRE(empty == "");
+    REQUIRE("" == empty);
+    REQUIRE_FALSE((str1 == ""));
+    REQUIRE_FALSE(("" == str1));
+
+    // Compile-time checks
+    STATIC_REQUIRE(str1 == "Hello");
+    STATIC_REQUIRE("Hello" == str1);
+    STATIC_REQUIRE_FALSE((str1 == "World"));
+    STATIC_REQUIRE_FALSE(("World" == str1));
+    STATIC_REQUIRE(empty == "");
+    STATIC_REQUIRE("" == empty);
+    STATIC_REQUIRE_FALSE((str1 == ""));
+    STATIC_REQUIRE_FALSE(("" == str1));
+  }
+
+  SECTION("Edge cases") {
+    constexpr CStringView str1("A");
+    constexpr CStringView str2("B");
+    constexpr CStringView empty1;
+    constexpr CStringView empty2;
+
+    // Single character comparison
+    REQUIRE(str1 == "A");
+    REQUIRE("A" == str1);
+    REQUIRE_FALSE((str1 == "B"));
+    REQUIRE_FALSE(("B" == str1));
+
+    // Empty string comparisons
+    REQUIRE(empty1 == empty2);
+    REQUIRE(empty2 == empty1);
+    REQUIRE(empty1 == "");
+    REQUIRE("" == empty1);
+
+    // Different sizes with same content
+    constexpr CStringView small("Hi");
+    constexpr CStringView large("Hi");
+
+    REQUIRE(small == large);
+    REQUIRE(large == small);
+
+    // Compile-time checks
+    STATIC_REQUIRE(str1 == "A");
+    STATIC_REQUIRE("A" == str1);
+    STATIC_REQUIRE_FALSE((str1 == "B"));
+    STATIC_REQUIRE_FALSE(("B" == str1));
+
+    STATIC_REQUIRE(empty1 == empty2);
+    STATIC_REQUIRE(empty2 == empty1);
+    STATIC_REQUIRE(empty1 == "");
+    STATIC_REQUIRE("" == empty1);
+
+    STATIC_REQUIRE(small == large);
+    STATIC_REQUIRE(large == small);
+  }
+
+  SECTION("Special characters") {
+    constexpr CStringView str1("Hello\nWorld");
+    constexpr CStringView str2("Hello\tWorld");
+    constexpr CStringView str3("Hello World");
+
+    REQUIRE(str1 == "Hello\nWorld");
+    REQUIRE("Hello\nWorld" == str1);
+    REQUIRE(str2 == "Hello\tWorld");
+    REQUIRE("Hello\tWorld" == str2);
+    REQUIRE_FALSE((str1 == str2));
+    REQUIRE_FALSE((str2 == str1));
+    REQUIRE_FALSE((str1 == str3));
+    REQUIRE_FALSE((str3 == str1));
+
+    // Compile-time checks
+    STATIC_REQUIRE(str1 == "Hello\nWorld");
+    STATIC_REQUIRE("Hello\nWorld" == str1);
+    STATIC_REQUIRE(str2 == "Hello\tWorld");
+    STATIC_REQUIRE("Hello\tWorld" == str2);
+    STATIC_REQUIRE_FALSE((str1 == str2));
+    STATIC_REQUIRE_FALSE((str2 == str1));
+    STATIC_REQUIRE_FALSE((str1 == str3));
+    STATIC_REQUIRE_FALSE((str3 == str1));
+  }
+
+  SECTION("Unicode content") {
+    constexpr CStringView str1("Привет");
+    constexpr CStringView str2("Мир");
+    constexpr CStringView str3("Привет");
+
+    REQUIRE(str1 == "Привет");
+    REQUIRE("Привет" == str1);
+    REQUIRE(str1 == str3);
+    REQUIRE(str3 == str1);
+    REQUIRE_FALSE((str1 == str2));
+    REQUIRE_FALSE((str2 == str1));
+
+    // Compile-time checks
+    STATIC_REQUIRE(str1 == "Привет");
+    STATIC_REQUIRE("Привет" == str1);
+    STATIC_REQUIRE(str1 == str3);
+    STATIC_REQUIRE(str3 == str1);
+    STATIC_REQUIRE_FALSE((str1 == str2));
+    STATIC_REQUIRE_FALSE((str2 == str1));
+  }
+
+  SECTION("Performance test") {
+    constexpr CStringView str1("This is a longer string for performance testing");
+    constexpr CStringView str2("This is a longer string for performance testing");
+    constexpr CStringView str3("This is a different string for performance testing");
+
+    REQUIRE(str1 == str2);
+    REQUIRE(str2 == str1);
+    REQUIRE_FALSE((str1 == str3));
+    REQUIRE_FALSE((str3 == str1));
+
+    // Compile-time checks
+    STATIC_REQUIRE(str1 == str2);
+    STATIC_REQUIRE(str2 == str1);
+    STATIC_REQUIRE_FALSE((str1 == str3));
+    STATIC_REQUIRE_FALSE((str3 == str1));
+  }
+
+  SECTION("Constexpr operations") {
+    constexpr CStringView str1("Test");
+    constexpr CStringView str2("Test");
+    constexpr CStringView str3("Different");
+
+    constexpr bool eq1 = str1 == str2;
+    constexpr bool eq2 = str1 == str3;
+    constexpr bool eq3 = str1 == "Test";
+    constexpr bool eq4 = "Test" == str1;
+    constexpr bool eq5 = str1 == "Different";
+    constexpr bool eq6 = "Different" == str1;
+
+    REQUIRE(eq1);
+    REQUIRE_FALSE(eq2);
+    REQUIRE(eq3);
+    REQUIRE(eq4);
+    REQUIRE_FALSE(eq5);
+    REQUIRE_FALSE(eq6);
+
+    // Compile-time checks
+    STATIC_REQUIRE(eq1);
+    STATIC_REQUIRE_FALSE(eq2);
+    STATIC_REQUIRE(eq3);
+    STATIC_REQUIRE(eq4);
+    STATIC_REQUIRE_FALSE(eq5);
+    STATIC_REQUIRE_FALSE(eq6);
+  }
+}

--- a/test/core/c_string_view_test.cpp
+++ b/test/core/c_string_view_test.cpp
@@ -4932,3 +4932,328 @@ TEST_CASE("CStringView operator==", "[core][c_string_view]") {
     STATIC_REQUIRE_FALSE(eq6);
   }
 }
+
+TEST_CASE("CStringView operator<=>", "[core][c_string_view]") {
+  SECTION("CStringView <=> CStringView") {
+    constexpr CStringView str1("Hello");
+    constexpr CStringView str2("Hello");
+    constexpr CStringView str3("World");
+    constexpr CStringView str4("Hi");
+    constexpr CStringView str5("Hell");
+
+    // Equal strings
+    REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
+    REQUIRE((str2 <=> str1) == std::strong_ordering::equal);
+
+    // Different strings
+    REQUIRE((str1 <=> str3) == std::strong_ordering::less);
+    REQUIRE((str3 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str1 <=> str4) == std::strong_ordering::less);
+    REQUIRE((str4 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str1 <=> str5) == std::strong_ordering::greater);
+    REQUIRE((str5 <=> str1) == std::strong_ordering::less);
+
+    // Compile-time checks
+    STATIC_REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
+    STATIC_REQUIRE((str2 <=> str1) == std::strong_ordering::equal);
+
+    STATIC_REQUIRE((str1 <=> str3) == std::strong_ordering::less);
+    STATIC_REQUIRE((str3 <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str1 <=> str4) == std::strong_ordering::less);
+    STATIC_REQUIRE((str4 <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str1 <=> str5) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str5 <=> str1) == std::strong_ordering::less);
+  }
+
+  SECTION("CStringView <=> StringLike") {
+    constexpr CStringView str("Hello");
+    const std::string stdStr1("Hello");
+    const std::string stdStr2("World");
+
+    REQUIRE((str <=> stdStr1) == std::strong_ordering::equal);
+    REQUIRE((stdStr1 <=> str) == std::strong_ordering::equal);
+    REQUIRE((str <=> stdStr2) == std::strong_ordering::less);
+    REQUIRE((stdStr2 <=> str) == std::strong_ordering::greater);
+  }
+
+  SECTION("CStringView <=> C string") {
+    constexpr CStringView str1("Hello");
+    constexpr const char * str2 = "Hello";
+    constexpr const char * str3 = "World";
+    constexpr const char * str4 = "Hi";
+    constexpr const char * str5 = "Hell";
+
+    // Equal strings
+    REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
+    REQUIRE((str2 <=> str1) == std::strong_ordering::equal);
+
+    // Different strings
+    REQUIRE((str1 <=> str3) == std::strong_ordering::less);
+    REQUIRE((str3 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str1 <=> str4) == std::strong_ordering::less);
+    REQUIRE((str4 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str1 <=> str5) == std::strong_ordering::greater);
+    REQUIRE((str5 <=> str1) == std::strong_ordering::less);
+
+    // Compile-time checks
+    STATIC_REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
+    STATIC_REQUIRE((str2 <=> str1) == std::strong_ordering::equal);
+
+    STATIC_REQUIRE((str1 <=> str3) == std::strong_ordering::less);
+    STATIC_REQUIRE((str3 <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str1 <=> str4) == std::strong_ordering::less);
+    STATIC_REQUIRE((str4 <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str1 <=> str5) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str5 <=> str1) == std::strong_ordering::less);
+  }
+
+  SECTION("Empty string comparisons") {
+    constexpr CStringView empty1("");
+    constexpr CStringView empty2("");
+    constexpr CStringView nonEmpty("Test");
+    constexpr const char * emptyCStr = "";
+    constexpr const char * nonEmptyCStr = "Test";
+
+    // Empty vs empty
+    REQUIRE((empty1 <=> empty2) == std::strong_ordering::equal);
+    REQUIRE((empty2 <=> empty1) == std::strong_ordering::equal);
+    REQUIRE((empty1 <=> emptyCStr) == std::strong_ordering::equal);
+    REQUIRE((emptyCStr <=> empty1) == std::strong_ordering::equal);
+
+    // Empty vs non-empty
+    REQUIRE((empty1 <=> nonEmpty) == std::strong_ordering::less);
+    REQUIRE((nonEmpty <=> empty1) == std::strong_ordering::greater);
+    REQUIRE((empty1 <=> nonEmptyCStr) == std::strong_ordering::less);
+    REQUIRE((nonEmptyCStr <=> empty1) == std::strong_ordering::greater);
+
+    // Compile-time checks
+    STATIC_REQUIRE((empty1 <=> empty2) == std::strong_ordering::equal);
+    STATIC_REQUIRE((empty2 <=> empty1) == std::strong_ordering::equal);
+    STATIC_REQUIRE((empty1 <=> emptyCStr) == std::strong_ordering::equal);
+    STATIC_REQUIRE((emptyCStr <=> empty1) == std::strong_ordering::equal);
+
+    STATIC_REQUIRE((empty1 <=> nonEmpty) == std::strong_ordering::less);
+    STATIC_REQUIRE((nonEmpty <=> empty1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((empty1 <=> nonEmptyCStr) == std::strong_ordering::less);
+    STATIC_REQUIRE((nonEmptyCStr <=> empty1) == std::strong_ordering::greater);
+  }
+
+  SECTION("Single character strings") {
+    constexpr CStringView str1("A");
+    constexpr CStringView str2("B");
+    constexpr CStringView str3("A");
+    constexpr CStringView str4("Z");
+
+    // Equal single characters
+    REQUIRE((str1 <=> str3) == std::strong_ordering::equal);
+    REQUIRE((str3 <=> str1) == std::strong_ordering::equal);
+
+    // Different single characters
+    REQUIRE((str1 <=> str2) == std::strong_ordering::less);
+    REQUIRE((str2 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str1 <=> str4) == std::strong_ordering::less);
+    REQUIRE((str4 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str2 <=> str4) == std::strong_ordering::less);
+    REQUIRE((str4 <=> str2) == std::strong_ordering::greater);
+
+    // Compile-time checks
+    STATIC_REQUIRE((str1 <=> str3) == std::strong_ordering::equal);
+    STATIC_REQUIRE((str3 <=> str1) == std::strong_ordering::equal);
+
+    STATIC_REQUIRE((str1 <=> str2) == std::strong_ordering::less);
+    STATIC_REQUIRE((str2 <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str1 <=> str4) == std::strong_ordering::less);
+    STATIC_REQUIRE((str4 <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str2 <=> str4) == std::strong_ordering::less);
+    STATIC_REQUIRE((str4 <=> str2) == std::strong_ordering::greater);
+  }
+
+  SECTION("Case sensitivity") {
+    constexpr CStringView lower("hello");
+    constexpr CStringView upper("HELLO");
+    constexpr CStringView mixed("Hello");
+
+    // Case-sensitive comparisons
+    REQUIRE((lower <=> upper) == std::strong_ordering::greater); // 'h' > 'H' in ASCII
+    REQUIRE((upper <=> lower) == std::strong_ordering::less);
+    REQUIRE((lower <=> mixed) == std::strong_ordering::greater); // 'h' > 'H' in ASCII
+    REQUIRE((mixed <=> lower) == std::strong_ordering::less);
+    REQUIRE((upper <=> mixed) == std::strong_ordering::less); // 'H' < 'H' (same), but 'E' < 'e'
+    REQUIRE((mixed <=> upper) == std::strong_ordering::greater);
+
+    // Compile-time checks
+    STATIC_REQUIRE((lower <=> upper) == std::strong_ordering::greater);
+    STATIC_REQUIRE((upper <=> lower) == std::strong_ordering::less);
+    STATIC_REQUIRE((lower <=> mixed) == std::strong_ordering::greater);
+    STATIC_REQUIRE((mixed <=> lower) == std::strong_ordering::less);
+    STATIC_REQUIRE((upper <=> mixed) == std::strong_ordering::less);
+    STATIC_REQUIRE((mixed <=> upper) == std::strong_ordering::greater);
+  }
+
+  SECTION("Prefix comparisons") {
+    constexpr CStringView str1("Hello");
+    constexpr CStringView str2("HelloWorld");
+    constexpr CStringView str3("Hell");
+    constexpr CStringView str4("Hello");
+
+    // One string is prefix of another
+    REQUIRE((str1 <=> str2) == std::strong_ordering::less); // "Hello" < "HelloWorld"
+    REQUIRE((str2 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str3 <=> str1) == std::strong_ordering::less); // "Hell" < "Hello"
+    REQUIRE((str1 <=> str3) == std::strong_ordering::greater);
+
+    // Equal strings
+    REQUIRE((str1 <=> str4) == std::strong_ordering::equal);
+    REQUIRE((str4 <=> str1) == std::strong_ordering::equal);
+
+    // Compile-time checks
+    STATIC_REQUIRE((str1 <=> str2) == std::strong_ordering::less);
+    STATIC_REQUIRE((str2 <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str3 <=> str1) == std::strong_ordering::less);
+    STATIC_REQUIRE((str1 <=> str3) == std::strong_ordering::greater);
+
+    STATIC_REQUIRE((str1 <=> str4) == std::strong_ordering::equal);
+    STATIC_REQUIRE((str4 <=> str1) == std::strong_ordering::equal);
+  }
+
+  SECTION("Special characters") {
+    constexpr CStringView str1("Hello\nWorld");
+    constexpr CStringView str2("Hello\tWorld");
+    constexpr CStringView str3("Hello World");
+    constexpr CStringView str4("Hello\nWorld");
+
+    // Equal strings with special characters
+    REQUIRE((str1 <=> str4) == std::strong_ordering::equal);
+    REQUIRE((str4 <=> str1) == std::strong_ordering::equal);
+
+    // Different special characters
+    REQUIRE((str1 <=> str2) == std::strong_ordering::greater); // '\n' > '\t' in ASCII
+    REQUIRE((str2 <=> str1) == std::strong_ordering::less);
+    REQUIRE((str1 <=> str3) == std::strong_ordering::less); // '\n' < ' ' in ASCII
+    REQUIRE((str3 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str2 <=> str3) == std::strong_ordering::less); // '\t' < ' ' in ASCII
+    REQUIRE((str3 <=> str2) == std::strong_ordering::greater);
+
+    // Compile-time checks
+    STATIC_REQUIRE((str1 <=> str4) == std::strong_ordering::equal);
+    STATIC_REQUIRE((str4 <=> str1) == std::strong_ordering::equal);
+
+    STATIC_REQUIRE((str1 <=> str2) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str2 <=> str1) == std::strong_ordering::less);
+    STATIC_REQUIRE((str1 <=> str3) == std::strong_ordering::less);
+    STATIC_REQUIRE((str3 <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str2 <=> str3) == std::strong_ordering::less);
+    STATIC_REQUIRE((str3 <=> str2) == std::strong_ordering::greater);
+  }
+
+  SECTION("Unicode content") {
+    constexpr CStringView str1("Привет");
+    constexpr CStringView str2("Мир");
+    constexpr CStringView str3("Привет");
+    constexpr CStringView str4("Hello 🌍");
+
+    // Equal Unicode strings
+    REQUIRE((str1 <=> str3) == std::strong_ordering::equal);
+    REQUIRE((str3 <=> str1) == std::strong_ordering::equal);
+
+    // Different Unicode strings
+    REQUIRE((str1 <=> str2) != std::strong_ordering::equal);
+    REQUIRE((str2 <=> str1) != std::strong_ordering::equal);
+    REQUIRE((str1 <=> str4) != std::strong_ordering::equal);
+    REQUIRE((str4 <=> str1) != std::strong_ordering::equal);
+
+    // Compile-time checks
+    STATIC_REQUIRE((str1 <=> str3) == std::strong_ordering::equal);
+    STATIC_REQUIRE((str3 <=> str1) == std::strong_ordering::equal);
+
+    STATIC_REQUIRE((str1 <=> str2) != std::strong_ordering::equal);
+    STATIC_REQUIRE((str2 <=> str1) != std::strong_ordering::equal);
+    STATIC_REQUIRE((str1 <=> str4) != std::strong_ordering::equal);
+    STATIC_REQUIRE((str4 <=> str1) != std::strong_ordering::equal);
+  }
+
+  SECTION("Numeric strings") {
+    constexpr CStringView str1("123");
+    constexpr CStringView str2("456");
+    constexpr CStringView str3("123");
+    constexpr CStringView str4("12");
+    constexpr CStringView str5("1234");
+
+    // Equal numeric strings
+    REQUIRE((str1 <=> str3) == std::strong_ordering::equal);
+    REQUIRE((str3 <=> str1) == std::strong_ordering::equal);
+
+    // Different numeric strings
+    REQUIRE((str1 <=> str2) == std::strong_ordering::less); // "123" < "456"
+    REQUIRE((str2 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str1 <=> str4) == std::strong_ordering::greater); // "123" > "12"
+    REQUIRE((str4 <=> str1) == std::strong_ordering::less);
+    REQUIRE((str1 <=> str5) == std::strong_ordering::less); // "123" < "1234"
+    REQUIRE((str5 <=> str1) == std::strong_ordering::greater);
+
+    // Compile-time checks
+    STATIC_REQUIRE((str1 <=> str3) == std::strong_ordering::equal);
+    STATIC_REQUIRE((str3 <=> str1) == std::strong_ordering::equal);
+
+    STATIC_REQUIRE((str1 <=> str2) == std::strong_ordering::less);
+    STATIC_REQUIRE((str2 <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str1 <=> str4) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str4 <=> str1) == std::strong_ordering::less);
+    STATIC_REQUIRE((str1 <=> str5) == std::strong_ordering::less);
+    STATIC_REQUIRE((str5 <=> str1) == std::strong_ordering::greater);
+  }
+
+  SECTION("Constexpr operations") {
+    constexpr CStringView str1("Test");
+    constexpr CStringView str2("Test");
+    constexpr CStringView str3("Different");
+    constexpr CStringView str4("Test");
+    constexpr const char * str5 = "Test";
+    constexpr const char * str6 = "Different";
+
+    constexpr auto eq1 = str1 <=> str2;
+    constexpr auto eq2 = str1 <=> str3;
+    constexpr auto eq3 = str1 <=> str4;
+    constexpr auto eq4 = str1 <=> str5;
+    constexpr auto eq5 = str1 <=> str6;
+    constexpr auto eq6 = str5 <=> str1;
+
+    REQUIRE(eq1 == std::strong_ordering::equal);
+    REQUIRE(eq2 != std::strong_ordering::equal);
+    REQUIRE(eq3 == std::strong_ordering::equal);
+    REQUIRE(eq4 == std::strong_ordering::equal);
+    REQUIRE(eq5 != std::strong_ordering::equal);
+    REQUIRE(eq6 == std::strong_ordering::equal);
+
+    // Compile-time checks
+    STATIC_REQUIRE(eq1 == std::strong_ordering::equal);
+    STATIC_REQUIRE(eq2 != std::strong_ordering::equal);
+    STATIC_REQUIRE(eq3 == std::strong_ordering::equal);
+    STATIC_REQUIRE(eq4 == std::strong_ordering::equal);
+    STATIC_REQUIRE(eq5 != std::strong_ordering::equal);
+    STATIC_REQUIRE(eq6 == std::strong_ordering::equal);
+  }
+
+  SECTION("Performance test") {
+    constexpr CStringView str1("This is a very long string for performance testing");
+    constexpr CStringView str2("This is a very long string for performance testing");
+    constexpr CStringView str3("This is a very long string for performance testing!");
+    constexpr CStringView str4("This is a different string for performance testing");
+
+    // Equal long strings
+    REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
+    REQUIRE((str2 <=> str1) == std::strong_ordering::equal);
+
+    // Different long strings
+    REQUIRE((str1 <=> str3) == std::strong_ordering::less); // Missing '!' at end
+    REQUIRE((str3 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str1 <=> str4) != std::strong_ordering::equal); // Different content
+    REQUIRE((str4 <=> str1) != std::strong_ordering::equal);
+
+    // Compile-time checks
+    STATIC_REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
+    STATIC_REQUIRE((str2 <=> str1) == std::strong_ordering::equal);
+    STATIC_REQUIRE((str1 <=> str3) == std::strong_ordering::less);
+    STATIC_REQUIRE((str3 <=> str1) == std::strong_ordering::greater);
+  }
+}

--- a/test/core/fix_string_test.cpp
+++ b/test/core/fix_string_test.cpp
@@ -8975,18 +8975,11 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
     constexpr FixedString<16> str("Hello");
     const std::string stdStr1("Hello");
     const std::string stdStr2("World");
-    constexpr CStringView strView1("Hello");
-    constexpr CStringView strView2("World");
 
     REQUIRE((str <=> stdStr1) == std::strong_ordering::equal);
     REQUIRE((stdStr1 <=> str) == std::strong_ordering::equal);
     REQUIRE((str <=> stdStr2) == std::strong_ordering::less);
     REQUIRE((stdStr2 <=> str) == std::strong_ordering::greater);
-
-    STATIC_REQUIRE((str <=> strView1) == std::strong_ordering::equal);
-    STATIC_REQUIRE((strView1 <=> str) == std::strong_ordering::equal);
-    STATIC_REQUIRE((str <=> strView2) == std::strong_ordering::less);
-    STATIC_REQUIRE((strView2 <=> str) == std::strong_ordering::greater);
   }
 
   SECTION("FixedString <=> C string") {

--- a/test/core/fix_string_test.cpp
+++ b/test/core/fix_string_test.cpp
@@ -8769,9 +8769,6 @@ TEST_CASE("FixedString operator==", "[core][fixed_string]") {
     const std::string stdStr1;
     const std::string stdStr2("Hello");
     const std::string stdStr3("World");
-    constexpr CStringView strView1;
-    constexpr CStringView strView2("Hello");
-    constexpr CStringView strView3("World");
 
     REQUIRE_FALSE((str == stdStr1));
     REQUIRE_FALSE((stdStr1 == str));
@@ -8779,13 +8776,6 @@ TEST_CASE("FixedString operator==", "[core][fixed_string]") {
     REQUIRE(stdStr2 == str);
     REQUIRE_FALSE((str == stdStr3));
     REQUIRE_FALSE((stdStr3 == str));
-
-    STATIC_REQUIRE_FALSE((str == strView1));
-    STATIC_REQUIRE_FALSE((strView1 == str));
-    STATIC_REQUIRE(str == strView2);
-    STATIC_REQUIRE(strView2 == str);
-    STATIC_REQUIRE_FALSE((str == strView3));
-    STATIC_REQUIRE_FALSE((strView3 == str));
   }
 
   SECTION("FixedString == C string") {


### PR DESCRIPTION
### **User description**
close #119


___

### **PR Type**
Enhancement


___

### **Description**
- Add equality (`operator==`) and three-way comparison (`operator<=>`) operators for `CStringView`

- Support comparisons with other `CStringView`, `StringLike` types, and C strings

- Include comprehensive test coverage for all comparison scenarios

- Remove redundant `CStringView` comparison tests from `FixedString` test suite


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CStringView Class"] --> B["operator== overloads"]
  A --> C["operator<=> overloads"]
  B --> D["CStringView vs CStringView"]
  B --> E["CStringView vs StringLike"]
  B --> F["CStringView vs C string"]
  C --> G["Three-way comparisons"]
  G --> H["std::strong_ordering"]
  I["Test Suite"] --> J["Comprehensive test coverage"]
  J --> K["Edge cases & Unicode"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>c_string_view.hpp</strong><dd><code>Add comparison operator declarations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/core/c_string_view.hpp

<ul><li>Add <code>operator==</code> declarations for all comparison combinations<br> <li> Add <code>operator<=></code> declarations for three-way comparisons<br> <li> Include comprehensive documentation with preconditions and notes<br> <li> Support template overloads for <code>StringLike</code> concept</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/123/files#diff-9d334ca7b15ac828f1536b20c0fcfd89f80a8970841385b4b869e2dd4ae26849">+210/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>c_string_view.inl</strong><dd><code>Implement comparison operator logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/core/c_string_view.inl

<ul><li>Implement <code>operator==</code> with compile-time and runtime string comparison<br> <li> Implement <code>operator<=></code> returning <code>std::strong_ordering</code><br> <li> Handle edge cases like empty strings and self-comparison<br> <li> Use <code>cstrcmp</code> for constexpr contexts and <code>std::strcmp</code> for runtime</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/123/files#diff-19b0d72c816318d3ee02d11b157d8b518d3c1d3e7eef9964ffae8b3efec84534">+113/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>c_string_view_test.cpp</strong><dd><code>Add comprehensive comparison operator tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/core/c_string_view_test.cpp

<ul><li>Add comprehensive test cases for <code>operator==</code> with various string types<br> <li> Add extensive test cases for <code>operator<=></code> with lexicographic ordering<br> <li> Include tests for edge cases, Unicode, special characters, and <br>performance<br> <li> Add <code>std::swap</code> functionality tests for <code>CStringView</code> objects</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/123/files#diff-2e6a5805b82d6df486ae0d658f5172c7ba8c1a58847a5bb3d7b57e6167c37188">+669/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fix_string_test.cpp</strong><dd><code>Remove redundant CStringView tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/core/fix_string_test.cpp

<ul><li>Remove redundant <code>CStringView</code> comparison tests from <code>FixedString</code> test <br>suite<br> <li> Clean up test sections that were testing <code>CStringView</code> functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/123/files#diff-cc1ff39c1921067e1cd9ffcf0bc8c8f3d7349f0178f1eb6ddeac099bc0a2d2ae">+0/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

