### PR TITLE
test(core): improve fixed_string test coverage and simplify utility function docs

### DIFF
--- a/include/core/fixed_string.inl
+++ b/include/core/fixed_string.inl
@@ -107,9 +107,6 @@ constexpr FixedString<allocatedSize> & FixedString<allocatedSize>::operator=(
 template <std::size_t allocatedSize>
 template <StringLike stringType>
 constexpr FixedString<allocatedSize> & FixedString<allocatedSize>::operator=(const stringType & string) noexcept {
-  if (_data == string.c_str())
-    return *this;
-
   assert_message(string.size() < allocatedSize, "String size must not exceed capacity");
 
   _size = string.size();
@@ -176,12 +173,6 @@ constexpr FixedString<allocatedSize> & FixedString<allocatedSize>::assign(
 template <std::size_t allocatedSize>
 template <StringLike stringType>
 constexpr FixedString<allocatedSize> & FixedString<allocatedSize>::assign(const stringType & string) noexcept {
-  if (_data == string.c_str()) {
-    assert_message(_size == string.size(), "Aliased assign requires matching sizes");
-
-    return *this;
-  }
-
   assert_message(string.size() < allocatedSize, "String size must not exceed capacity");
 
   _size = string.size();

--- a/include/core/utils.hpp
+++ b/include/core/utils.hpp
@@ -305,86 +305,59 @@ char * itoa(char * dest, std::size_t destSize, std::uint32_t value, unsigned bas
 char * itoa(char * dest, std::size_t destSize, std::uint64_t value, unsigned base) noexcept;
 
 /*!
-  \brief Converts a 32-bit floating-point number to its string representation with specified precision.
+  \brief Converts a 32-bit floating-point number to its C string representation with specified precision.
 
-  This function converts a given 32-bit floating-point number into its decimal string representation, storing the result
-  in the provided destination buffer. The conversion supports configurable precision and handles special values.
+  This function converts a given 32-bit floating-point number into its decimal C string representation, storing the
+  result in the provided destination buffer. The conversion supports configurable precision and handles special values.
 
-  \param dest      A pointer to the destination buffer where the converted string is stored.
+  \param dest      A pointer to the destination buffer where the converted C string is stored.
   \param destSize  The size of the destination buffer in characters.
   \param value     The 32-bit floating-point number to be converted.
   \param precision The precision (digits after the decimal point). Default is 7, practical limit is ~7-9 digits.
 
-  \return A pointer to the destination buffer containing the converted string.
-
-  \pre The destination buffer must be valid and have sufficient capacity.
-  \pre The precision should be reasonable (typically ≤ 9 for float).
-
-  \post The destination string is null-terminated.
-  \post Special values (inf, -inf, nan) are properly represented.
-  \post The result uses fixed-point notation (not scientific).
+  \return A pointer to the destination buffer containing the converted C string.
 
   \note The function handles special IEEE-754 values (infinity, NaN).
   \note The function does not support subnormal numbers.
   \note Precision beyond ~7-9 digits may not be meaningful for float.
   \note The function uses efficient bit manipulation for conversion.
-  \note The function is thread-safe for single-buffer operations.
 */
 char * ftoa(char * dest, std::size_t destSize, float value, std::size_t precision = 7) noexcept;
 
 /*!
-  \brief Converts a 64-bit floating-point number to its string representation with specified precision.
+  \brief Converts a 64-bit floating-point number to its C string representation with specified precision.
 
-  This function converts a given 64-bit floating-point number into its decimal string representation, storing the result
-  in the provided destination buffer. The conversion supports configurable precision and handles special values.
+  This function converts a given 64-bit floating-point number into its decimal C string representation, storing the
+  result in the provided destination buffer. The conversion supports configurable precision and handles special values.
 
-  \param dest      A pointer to the destination buffer where the converted string is stored.
+  \param dest      A pointer to the destination buffer where the converted C string is stored.
   \param destSize  The size of the destination buffer in characters.
   \param value     The 64-bit floating-point number to be converted.
   \param precision The precision (digits after the decimal point). Default is 15, practical limit is ~15–17 digits.
 
-  \return A pointer to the destination buffer containing the converted string.
-
-  \pre The destination buffer must be valid and have sufficient capacity.
-  \pre The precision should be reasonable (typically ≤ 17 for double).
-
-  \post The destination string is null-terminated.
-  \post Special values (inf, -inf, nan) are properly represented.
-  \post The result uses fixed-point notation (not scientific).
+  \return A pointer to the destination buffer containing the converted C string.
 
   \note The function handles special IEEE-754 values (infinity, NaN).
   \note The function does not support subnormal numbers.
-  \note Precision beyond ~15–17 digits may not be meaningful for float.
+  \note Precision beyond ~15–17 digits may not be meaningful for double.
   \note The function uses efficient bit manipulation for conversion.
-  \note The function is thread-safe for single-buffer operations.
 */
 char * ftoa(char * dest, std::size_t destSize, double value, std::size_t precision = 15) noexcept;
 
 /*!
-  \brief Formats a number string by inserting grouping separators.
+  \brief Formats a number C string by inserting grouping separators.
 
-  This function inserts a grouping separator (e.g., comma, space, or dot) into a number string every three digits,
+  This function inserts a grouping \a separator (e.g., comma, space, or dot) into a number C string every three digits,
   starting from the right. This is commonly used for formatting large numbers to improve readability (e.g.,
   "1,234,567").
 
-  \param buffer     A pointer to the buffer where the formatted string is stored.
+  \param buffer     A pointer to the buffer where the formatted C string is stored.
   \param bufferSize The size of the buffer in characters.
   \param separator  A pointer to the grouping separator C string to insert (e.g., ",", " ", ".").
 
-  \pre The buffer must be valid and contain a null-terminated number string.
-  \pre The bufferSize must be sufficient to accommodate the formatted result.
-  \pre The separator must not be null and should be reasonable in length (≤ 8 characters).
-  \pre The input string should contain only digits (no decimal points, signs, or other characters).
-
-  \post The buffer contains the formatted number string with grouping separators.
-  \post The function modifies the buffer in-place.
-  \post The function returns early if the buffer is too small for the result.
-
-  \note The function validates available capacity before modification.
+  \note The function modifies the \a buffer in-place.
   \note Grouping separators are inserted every three digits from the right.
   \note The function handles edge cases gracefully (empty string, single digits, etc.).
-  \note The function is thread-safe for single-buffer operations.
-  \note Performance is optimized for common number string lengths.
   \note The function does not validate that the input is purely numeric.
 */
 void formatNumberString(char * buffer, std::size_t bufferSize, const char * separator) noexcept;

--- a/test/core/fixed_string_test.cpp
+++ b/test/core/fixed_string_test.cpp
@@ -4096,6 +4096,16 @@ TEST_CASE("FixedString replace", "[core][fixed_string]") {
 
     REQUIRE(testString.size() == 9);
     REQUIRE(std::strcmp(testString.c_str(), "Hello ***") == 0);
+
+    testString.replace(2, 0, '*', 0);
+
+    REQUIRE(testString.size() == 9);
+    REQUIRE(std::strcmp(testString.c_str(), "Hello ***") == 0);
+
+    testString.replace(0, 5, '*', 5);
+
+    REQUIRE(testString.size() == 9);
+    REQUIRE(std::strcmp(testString.c_str(), "***** ***") == 0);
   }
 
   SECTION("Replace at beginning") {
@@ -8465,80 +8475,80 @@ TEST_CASE("FixedString operators+", "[core][fixed_string]") {
   }
 
   SECTION("FixedString + FixedString (same size)") {
-    constexpr auto result = FixedString<20>("Hello") + FixedString<20>("World");
-
+    auto result = FixedString<20>("Hello") + FixedString<20>("World");
     REQUIRE(result.size() == 10);
     REQUIRE(std::strcmp(result.c_str(), "HelloWorld") == 0);
 
     // Compile-time checks
-    STATIC_REQUIRE(result.size() == 10);
-    STATIC_REQUIRE(cstrcmp(result.c_str(), "HelloWorld") == 0);
+    constexpr auto constexprResult = FixedString<20>("Hello") + FixedString<20>("World");
+    STATIC_REQUIRE(constexprResult.size() == 10);
+    STATIC_REQUIRE(cstrcmp(constexprResult.c_str(), "HelloWorld") == 0);
   }
 
   SECTION("FixedString + FixedString (different sizes)") {
-    constexpr auto result = FixedString<20>("Hello") + FixedString<10>("World");
-
+    auto result = FixedString<20>("Hello") + FixedString<10>("World");
     REQUIRE(result.size() == 10);
     REQUIRE(std::strcmp(result.c_str(), "HelloWorld") == 0);
 
     // Compile-time checks
-    STATIC_REQUIRE(result.size() == 10);
-    STATIC_REQUIRE(cstrcmp(result.c_str(), "HelloWorld") == 0);
+    constexpr auto constexprResult = FixedString<20>("Hello") + FixedString<10>("World");
+    STATIC_REQUIRE(constexprResult.size() == 10);
+    STATIC_REQUIRE(cstrcmp(constexprResult.c_str(), "HelloWorld") == 0);
   }
 
   SECTION("FixedString + C-string") {
-    constexpr auto result = FixedString<20>("Hello") + "World";
-
+    auto result = FixedString<20>("Hello") + "World";
     REQUIRE(result.size() == 10);
     REQUIRE(std::strcmp(result.c_str(), "HelloWorld") == 0);
 
     // Compile-time checks
-    STATIC_REQUIRE(result.size() == 10);
-    STATIC_REQUIRE(cstrcmp(result.c_str(), "HelloWorld") == 0);
+    constexpr auto constexprResult = FixedString<20>("Hello") + "World";
+    STATIC_REQUIRE(constexprResult.size() == 10);
+    STATIC_REQUIRE(cstrcmp(constexprResult.c_str(), "HelloWorld") == 0);
   }
 
   SECTION("C-string + FixedString") {
-    constexpr auto result = "Hello" + FixedString<20>("World");
-
+    auto result = "Hello" + FixedString<20>("World");
     REQUIRE(result.size() == 10);
     REQUIRE(std::strcmp(result.c_str(), "HelloWorld") == 0);
 
     // Compile-time checks
-    STATIC_REQUIRE(result.size() == 10);
-    STATIC_REQUIRE(cstrcmp(result.c_str(), "HelloWorld") == 0);
+    constexpr auto constexprResult = "Hello" + FixedString<20>("World");
+    STATIC_REQUIRE(constexprResult.size() == 10);
+    STATIC_REQUIRE(cstrcmp(constexprResult.c_str(), "HelloWorld") == 0);
   }
 
   SECTION("FixedString + std::string (StringLike)") {
-    constexpr auto result = FixedString<20>("Hello") + std::string("World");
-
+    auto result = FixedString<20>("Hello") + std::string("World");
     REQUIRE(result.size() == 10);
     REQUIRE(std::strcmp(result.c_str(), "HelloWorld") == 0);
 
     // Compile-time checks
-    STATIC_REQUIRE(result.size() == 10);
-    STATIC_REQUIRE(cstrcmp(result.c_str(), "HelloWorld") == 0);
+    constexpr auto constexprResult = FixedString<20>("Hello") + std::string("World");
+    STATIC_REQUIRE(constexprResult.size() == 10);
+    STATIC_REQUIRE(cstrcmp(constexprResult.c_str(), "HelloWorld") == 0);
   }
 
   SECTION("std::string + FixedString (StringLike)") {
-    constexpr auto result = std::string("Hello") + FixedString<20>("World");
-
+    auto result = std::string("Hello") + FixedString<20>("World");
     REQUIRE(result.size() == 10);
     REQUIRE(std::strcmp(result.c_str(), "HelloWorld") == 0);
 
     // Compile-time checks
-    STATIC_REQUIRE(result.size() == 10);
-    STATIC_REQUIRE(cstrcmp(result.c_str(), "HelloWorld") == 0);
+    constexpr auto constexprResult = std::string("Hello") + FixedString<20>("World");
+    STATIC_REQUIRE(constexprResult.size() == 10);
+    STATIC_REQUIRE(cstrcmp(constexprResult.c_str(), "HelloWorld") == 0);
   }
 
   SECTION("Empty string concatenation") {
-    constexpr auto result = FixedString<20>("") + FixedString<20>("");
-
+    auto result = FixedString<20>("") + FixedString<20>("");
     REQUIRE(result.size() == 0);
     REQUIRE(std::strcmp(result.c_str(), "") == 0);
 
     // Compile-time checks
-    STATIC_REQUIRE(result.size() == 0);
-    STATIC_REQUIRE(cstrcmp(result.c_str(), "") == 0);
+    constexpr auto constexprResult = FixedString<20>("") + FixedString<20>("");
+    STATIC_REQUIRE(constexprResult.size() == 0);
+    STATIC_REQUIRE(cstrcmp(constexprResult.c_str(), "") == 0);
   }
 
   SECTION("One empty string concatenation") {

--- a/test/core/fixed_string_test.cpp
+++ b/test/core/fixed_string_test.cpp
@@ -9076,11 +9076,12 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
 
   SECTION("FixedString <=> StringLike") {
     constexpr FixedString<8> str("Hello");
-    constexpr FixedString<16> fullStr("Hello World");
+    constexpr FixedString<16> strFull("Hello World");
     constexpr FixedString<8> empty;
     const std::string stdStr1("Hello");
     const std::string stdStr2("World");
     const std::string stdStr3("Big");
+    const std::string stdFull("Hello World");
     const std::string stdEmpty;
 
     REQUIRE((str <=> stdStr1) == std::strong_ordering::equal);
@@ -9101,8 +9102,10 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
     REQUIRE((empty <=> stdEmpty) == std::strong_ordering::equal);
     REQUIRE((stdEmpty <=> empty) == std::strong_ordering::equal);
 
-    REQUIRE((fullStr <=> stdStr1) == std::strong_ordering::greater);
-    REQUIRE((stdStr1 <=> fullStr) == std::strong_ordering::less);
+    REQUIRE((strFull <=> stdStr1) == std::strong_ordering::greater);
+    REQUIRE((stdStr1 <=> strFull) == std::strong_ordering::less);
+    REQUIRE((str <=> stdFull) == std::strong_ordering::less);
+    REQUIRE((stdFull <=> str) == std::strong_ordering::greater);
   }
 
   SECTION("FixedString <=> C string") {
@@ -9113,9 +9116,12 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
     constexpr const char * str3 = "World";
     constexpr const char * str4 = "Hi";
     constexpr const char * str5 = "Hell";
+    constexpr const char * strFull = "Hello World";
 
     REQUIRE((fullStr <=> str2) == std::strong_ordering::greater);
     REQUIRE((str2 <=> fullStr) == std::strong_ordering::less);
+    REQUIRE((strFull <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str1 <=> strFull) == std::strong_ordering::less);
 
     // Equal strings
     REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
@@ -9128,8 +9134,15 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
     REQUIRE((str4 <=> str1) == std::strong_ordering::greater);
     REQUIRE((str1 <=> str5) == std::strong_ordering::greater);
     REQUIRE((str5 <=> str1) == std::strong_ordering::less);
+    REQUIRE((fullStr <=> str3) == std::strong_ordering::less);
+    REQUIRE((str3 <=> fullStr) == std::strong_ordering::greater);
 
     // Compile-time checks
+    STATIC_REQUIRE((fullStr <=> str2) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str2 <=> fullStr) == std::strong_ordering::less);
+    STATIC_REQUIRE((strFull <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str1 <=> strFull) == std::strong_ordering::less);
+
     STATIC_REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
     STATIC_REQUIRE((str2 <=> str1) == std::strong_ordering::equal);
 
@@ -9139,6 +9152,8 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
     STATIC_REQUIRE((str4 <=> str1) == std::strong_ordering::greater);
     STATIC_REQUIRE((str1 <=> str5) == std::strong_ordering::greater);
     STATIC_REQUIRE((str5 <=> str1) == std::strong_ordering::less);
+    STATIC_REQUIRE((fullStr <=> str3) == std::strong_ordering::less);
+    STATIC_REQUIRE((str3 <=> fullStr) == std::strong_ordering::greater);
   }
 
   SECTION("Empty string comparisons") {

--- a/test/core/fixed_string_test.cpp
+++ b/test/core/fixed_string_test.cpp
@@ -9109,51 +9109,72 @@ TEST_CASE("FixedString operator<=>", "[core][fixed_string]") {
   }
 
   SECTION("FixedString <=> C string") {
-    constexpr FixedString<16> fullStr("Hello World");
     constexpr FixedString<16> str1("Hello");
+    constexpr FixedString<16> str2("World");
+    constexpr FixedString<16> fullStr("Hello World");
 
-    constexpr const char * str2 = "Hello";
-    constexpr const char * str3 = "World";
-    constexpr const char * str4 = "Hi";
-    constexpr const char * str5 = "Hell";
+    constexpr const char * cStr1 = "Hello";
+    constexpr const char * cStr2 = "World";
+    constexpr const char * cStr3 = "Hi";
+    constexpr const char * cStr4 = "Hell";
     constexpr const char * strFull = "Hello World";
 
-    REQUIRE((fullStr <=> str2) == std::strong_ordering::greater);
-    REQUIRE((str2 <=> fullStr) == std::strong_ordering::less);
+    REQUIRE((fullStr <=> cStr1) == std::strong_ordering::greater);
+    REQUIRE((cStr1 <=> fullStr) == std::strong_ordering::less);
     REQUIRE((strFull <=> str1) == std::strong_ordering::greater);
     REQUIRE((str1 <=> strFull) == std::strong_ordering::less);
 
     // Equal strings
-    REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
-    REQUIRE((str2 <=> str1) == std::strong_ordering::equal);
+    REQUIRE((str1 <=> cStr1) == std::strong_ordering::equal);
+    REQUIRE((cStr1 <=> str1) == std::strong_ordering::equal);
+    REQUIRE((str2 <=> cStr2) == std::strong_ordering::equal);
+    REQUIRE((cStr2 <=> str2) == std::strong_ordering::equal);
 
     // Different strings
-    REQUIRE((str1 <=> str3) == std::strong_ordering::less);
-    REQUIRE((str3 <=> str1) == std::strong_ordering::greater);
-    REQUIRE((str1 <=> str4) == std::strong_ordering::less);
-    REQUIRE((str4 <=> str1) == std::strong_ordering::greater);
-    REQUIRE((str1 <=> str5) == std::strong_ordering::greater);
-    REQUIRE((str5 <=> str1) == std::strong_ordering::less);
-    REQUIRE((fullStr <=> str3) == std::strong_ordering::less);
-    REQUIRE((str3 <=> fullStr) == std::strong_ordering::greater);
+    REQUIRE((str1 <=> cStr2) == std::strong_ordering::less);
+    REQUIRE((cStr2 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str1 <=> cStr3) == std::strong_ordering::less);
+    REQUIRE((cStr3 <=> str1) == std::strong_ordering::greater);
+    REQUIRE((str1 <=> cStr4) == std::strong_ordering::greater);
+    REQUIRE((cStr4 <=> str1) == std::strong_ordering::less);
+
+    REQUIRE((str2 <=> cStr1) == std::strong_ordering::greater);
+    REQUIRE((cStr1 <=> str2) == std::strong_ordering::less);
+    REQUIRE((str2 <=> cStr3) == std::strong_ordering::greater);
+    REQUIRE((cStr3 <=> str2) == std::strong_ordering::less);
+    REQUIRE((str2 <=> cStr4) == std::strong_ordering::greater);
+    REQUIRE((cStr4 <=> str2) == std::strong_ordering::less);
+
+    REQUIRE((fullStr <=> cStr2) == std::strong_ordering::less);
+    REQUIRE((cStr2 <=> fullStr) == std::strong_ordering::greater);
 
     // Compile-time checks
-    STATIC_REQUIRE((fullStr <=> str2) == std::strong_ordering::greater);
-    STATIC_REQUIRE((str2 <=> fullStr) == std::strong_ordering::less);
+    STATIC_REQUIRE((fullStr <=> cStr1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((cStr1 <=> fullStr) == std::strong_ordering::less);
     STATIC_REQUIRE((strFull <=> str1) == std::strong_ordering::greater);
     STATIC_REQUIRE((str1 <=> strFull) == std::strong_ordering::less);
 
-    STATIC_REQUIRE((str1 <=> str2) == std::strong_ordering::equal);
-    STATIC_REQUIRE((str2 <=> str1) == std::strong_ordering::equal);
+    STATIC_REQUIRE((str1 <=> cStr1) == std::strong_ordering::equal);
+    STATIC_REQUIRE((cStr1 <=> str1) == std::strong_ordering::equal);
+    STATIC_REQUIRE((str2 <=> cStr2) == std::strong_ordering::equal);
+    STATIC_REQUIRE((cStr2 <=> str2) == std::strong_ordering::equal);
 
-    STATIC_REQUIRE((str1 <=> str3) == std::strong_ordering::less);
-    STATIC_REQUIRE((str3 <=> str1) == std::strong_ordering::greater);
-    STATIC_REQUIRE((str1 <=> str4) == std::strong_ordering::less);
-    STATIC_REQUIRE((str4 <=> str1) == std::strong_ordering::greater);
-    STATIC_REQUIRE((str1 <=> str5) == std::strong_ordering::greater);
-    STATIC_REQUIRE((str5 <=> str1) == std::strong_ordering::less);
-    STATIC_REQUIRE((fullStr <=> str3) == std::strong_ordering::less);
-    STATIC_REQUIRE((str3 <=> fullStr) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str1 <=> cStr2) == std::strong_ordering::less);
+    STATIC_REQUIRE((cStr2 <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str1 <=> cStr3) == std::strong_ordering::less);
+    STATIC_REQUIRE((cStr3 <=> str1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((str1 <=> cStr4) == std::strong_ordering::greater);
+    STATIC_REQUIRE((cStr4 <=> str1) == std::strong_ordering::less);
+
+    STATIC_REQUIRE((str2 <=> cStr1) == std::strong_ordering::greater);
+    STATIC_REQUIRE((cStr1 <=> str2) == std::strong_ordering::less);
+    STATIC_REQUIRE((str2 <=> cStr3) == std::strong_ordering::greater);
+    STATIC_REQUIRE((cStr3 <=> str2) == std::strong_ordering::less);
+    STATIC_REQUIRE((str2 <=> cStr4) == std::strong_ordering::greater);
+    STATIC_REQUIRE((cStr4 <=> str2) == std::strong_ordering::less);
+
+    STATIC_REQUIRE((fullStr <=> cStr2) == std::strong_ordering::less);
+    STATIC_REQUIRE((cStr2 <=> fullStr) == std::strong_ordering::greater);
   }
 
   SECTION("Empty string comparisons") {


### PR DESCRIPTION
### **PR Type**
Tests, Documentation


___

### **Description**
- Add edge case tests for `replace` method

- Simplify documentation comments in utility functions

- Fix constexpr compilation issues in operator+ tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Cases"] --> B["Replace Edge Cases"]
  A --> C["Operator+ Tests"]
  D["Documentation"] --> E["Simplified Comments"]
  C --> F["Fixed Constexpr Issues"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.hpp</strong><dd><code>Simplified utility function documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/core/utils.hpp

<ul><li>Simplified documentation comments for <code>ftoa</code> functions<br> <li> Removed verbose preconditions and postconditions<br> <li> Updated terminology from "string" to "C string"<br> <li> Fixed typo in double precision note</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/145/files#diff-00e29c7d12889a37a31701cd801c4009379851ffa46c1251d243b61c767b592b">+15/-42</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fixed_string_test.cpp</strong><dd><code>Enhanced replace tests and fixed constexpr issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/core/fixed_string_test.cpp

<ul><li>Added edge case tests for <code>replace</code> method with zero length operations<br> <li> Fixed constexpr compilation issues in operator+ tests<br> <li> Separated runtime and compile-time test assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/145/files#diff-b4c68f0f207e1f5c688df998dad912b8362e57e541c549011df164a15f905535">+38/-28</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

