### PR TITLE
fix(core): resolve sanitizer warnings (unsigned underflow, implicit conversions)

### DIFF
--- a/include/core/fixed_vector.hpp
+++ b/include/core/fixed_vector.hpp
@@ -163,7 +163,7 @@ public:
 
     \post The new vector has the same size and content as the source \a init.
   */
-  FixedVector(std::initializer_list<type> init) noexcept;
+  explicit FixedVector(std::initializer_list<type> init) noexcept;
 
   /*!
     \brief Copy assigns other FixedVector to this FixedVector.

--- a/src/core/hashes.cpp
+++ b/src/core/hashes.cpp
@@ -123,8 +123,10 @@ std::uint8_t crc8(const void * src, std::size_t size, std::uint8_t crc) noexcept
 
   const auto * data = static_cast<const std::uint8_t *>(src);
 
-  while (size--)
+  while (size > 0) {
+    --size;
     crc = _crc8Table[static_cast<std::size_t>(crc ^ *data++)];
+  }
 
   return crc;
 }
@@ -134,8 +136,10 @@ std::uint16_t crc16(const void * src, std::size_t size, std::uint16_t crc) noexc
 
   const auto * data = static_cast<const std::uint8_t *>(src);
 
-  while (size--)
+  while (size > 0) {
+    --size;
     crc = static_cast<std::uint16_t>((crc >> 8) ^ _crc16Table[static_cast<std::size_t>((crc ^ *data++) & 0xFF)]);
+  }
 
   return crc;
 }
@@ -147,8 +151,10 @@ std::uint32_t crc32(const void * src, std::size_t size, std::uint32_t crc) noexc
 
   crc = ~crc;
 
-  while (size--)
+  while (size > 0) {
+    --size;
     crc = _crc32Table[static_cast<std::size_t>((crc ^ (*data++)) & 0xff)] ^ (crc >> 8);
+  }
 
   return ~crc;
 }

--- a/test/core/fixed_vector_test.cpp
+++ b/test/core/fixed_vector_test.cpp
@@ -154,13 +154,13 @@ TEST_CASE("FixedVector constructors", "[core][fixed_vector]") {
   }
 
   SECTION("Double type constructor") {
-    const FixedVector<double, 4> doubleVec(3, 3.14);
+    const FixedVector<double, 4> doubleVec(3, 3.15);
 
     REQUIRE(doubleVec.size() == 3);
     REQUIRE(doubleVec.capacity() == 4);
-    REQUIRE(doubleVec[0] == 3.14);
-    REQUIRE(doubleVec[1] == 3.14);
-    REQUIRE(doubleVec[2] == 3.14);
+    REQUIRE(doubleVec[0] == 3.15);
+    REQUIRE(doubleVec[1] == 3.15);
+    REQUIRE(doubleVec[2] == 3.15);
   }
 
   SECTION("Bool type constructor") {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add `explicit` keyword to initializer list constructor

- Replace post-decrement with pre-decrement in loop conditions

- Refactor while loops to avoid undefined behavior with size_t

- Update test values for consistency and precision


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FixedVector Constructor"] -- "Add explicit keyword" --> B["Prevent implicit conversions"]
  C["CRC Hash Functions"] -- "Replace size-- with size > 0 check" --> D["Avoid unsigned underflow"]
  E["Test Suite"] -- "Update test values" --> F["Ensure consistency"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fixed_vector.hpp</strong><dd><code>Add explicit keyword to initializer constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/core/fixed_vector.hpp

<ul><li>Add <code>explicit</code> keyword to initializer list constructor to prevent <br>implicit conversions<br> <li> Improves type safety and prevents unintended constructor calls</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/158/files#diff-5b1f34cbe405ace7840f20236175cd524c075fa02158cfd9453895983780a9e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hashes.cpp</strong><dd><code>Fix unsigned underflow in CRC hash loops</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/hashes.cpp

<ul><li>Replace post-decrement <code>size--</code> with explicit <code>size > 0</code> check and <br>pre-decrement <code>--size</code><br> <li> Prevents undefined behavior with unsigned integer underflow in <code>crc8</code>, <br><code>crc16</code>, and <code>crc32</code> functions<br> <li> Improves code clarity and sanitizer compliance</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/158/files#diff-c2a571929312fb8c37e17bc4575a74e9d8f6125195f22e69cde20e8f25c9e4cb">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fixed_vector_test.cpp</strong><dd><code>Update double test value for consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/core/fixed_vector_test.cpp

<ul><li>Update double test value from <code>3.14</code> to <code>3.15</code> for consistency<br> <li> Applies change across all assertions in the double type constructor <br>test</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/158/files#diff-23569edf61c9bda055b16e8ede3e8b7bd2e1f61f777b02545d878fb913a2dccd">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

