### PR TITLE
infra: configure SonarCloud code coverage reporting

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -250,6 +250,12 @@ jobs:
           flags: units
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: unit_tests_coverage.info
+          path: out/build/linux-ninja-debug/unit_tests_coverage.info
+
   sonar-cloud:
     name: SonarCloud Analyzer
     # This job should be run only for the original repo (either pushes or pull requests originating from the same repo), forks are not allowed.
@@ -318,6 +324,11 @@ jobs:
           path: ${{ runner.temp }}/apt-cache
           key: ${{ steps.sonarcloudaptcache.outputs.cache-primary-key }}
 
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v5.0.0
+        with:
+          name: unit_tests_coverage.info
+
       - name: Prepare compile_commands.json
         run: |
           cmake -DTOYGINE_BUILD_TESTS=ON --preset linux-ninja-debug
@@ -328,6 +339,7 @@ jobs:
             -Dsonar.cfamily.compile-commands=out/build/linux-ninja-debug/compile_commands.json
             -Dsonar.cfamily.analysisCache.mode=fs
             -Dsonar.cfamily.analysisCache.path=.sonar-cfamily-cache
+            -Dsonar.cfamily.llvm-cov.reportPath=unit_tests_coverage.info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,4 +8,9 @@ sonar.projectName=ToyGine2
 sonar.sources=src/,include/
 sonar.tests=test/
 
+# Exclude build artifacts & migrations
+sonar.exclusions=out/**/*
+
+sonar.log.level=TRACE
+sonar.verbose=true
 sonar.coverage.exclusions=**


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add coverage artifact upload to CI pipeline

- Download coverage artifact in SonarCloud job

- Configure SonarQube to use LLVM coverage report

- Exclude build artifacts from SonarQube analysis

- Enable verbose logging for SonarQube analysis


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build & Generate Coverage"] -- "Upload artifact" --> B["Coverage Artifact Storage"]
  B -- "Download artifact" --> C["SonarCloud Job"]
  C -- "Process coverage" --> D["SonarQube Analysis"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_cmake.yaml</strong><dd><code>Add coverage artifact handling to CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build_cmake.yaml

<ul><li>Add step to upload coverage artifact using <br><code>actions/upload-artifact@v4.6.2</code><br> <li> Add step to download coverage artifact using <br><code>actions/download-artifact@v5.0.0</code> in SonarCloud job<br> <li> Configure SonarQube to use LLVM coverage report via <br><code>-Dsonar.cfamily.llvm-cov.reportPath</code> parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/171/files#diff-bc3780103c5af571852278102dbe54fab038285c66bf73583e54bf3f659c73ca">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sonar-project.properties</strong><dd><code>Configure SonarQube analysis and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sonar-project.properties

<ul><li>Add exclusion pattern to exclude build artifacts from analysis<br> <li> Enable trace-level logging for SonarQube<br> <li> Enable verbose output for SonarQube</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/171/files#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

