### PR TITLE
jacoco

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -351,7 +351,7 @@ jobs:
             -Dsonar.cfamily.compile-commands=out/build/linux-ninja-debug/compile_commands.json
             -Dsonar.cfamily.analysisCache.mode=fs
             -Dsonar.cfamily.analysisCache.path=.sonar-cfamily-cache
-            -Dsonar.cfamily.cobertura.reportPaths=out/coverage
+            -Dsonar.cfamily.cobertura.reportPaths=out/coverage/cobertura.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add Jacoco XML coverage format conversion step

- Upload converted Jacoco XML artifact for SonarCloud

- Replace LLVM coverage with Jacoco XML in SonarCloud analysis

- Install cover2cover tool to convert coverage formats


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LLVM Coverage Info"] -- "cover2cover conversion" --> B["Jacoco XML"]
  B -- "upload artifact" --> C["SonarCloud Analysis"]
  D["SonarCloud Config"] -- "use jacoco.xml path" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_cmake.yaml</strong><dd><code>Configure Jacoco XML coverage for SonarCloud</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build_cmake.yaml

<ul><li>Added step to convert LLVM coverage format to Jacoco XML using <br>cover2cover tool<br> <li> Added artifact upload step for the generated jacoco.xml file<br> <li> Added download step for jacoco.xml artifact in SonarCloud job<br> <li> Updated SonarCloud configuration to use Jacoco XML report instead of <br>LLVM coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/173/files#diff-bc3780103c5af571852278102dbe54fab038285c66bf73583e54bf3f659c73ca">+17/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

