### PR TITLE
ci: migrate to native container support in GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,17 @@ updates:
       interval: "daily"
     assignees:
       - "dependabot"
-    reviewers:
+      - "dkrutskikh"
+    commit-message:
+      prefix: "chore: "
+
+  # Maintain Docker images used in GitHub Actions
+  - package-ecosystem: "docker"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "dependabot"
       - "dkrutskikh"
     commit-message:
       prefix: "chore: "

--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -56,25 +56,25 @@ jobs:
 
           - name: DevkitPro GBA
             os: ubuntu-24.04
-            docker_image: devkitpro/devkitarm:latest
+            docker_image: devkitpro/devkitarm:20251117
             run_test: "false"
             cmake_preset: nintendo-gba-ninja-release
 
           - name: DevkitPro NDS
             os: ubuntu-24.04
-            docker_image: devkitpro/devkitarm:latest
+            docker_image: devkitpro/devkitarm:20251117
             run_test: "false"
             cmake_preset: nintendo-ds-ninja-release
 
           - name: DevkitPro 3DS
             os: ubuntu-24.04
-            docker_image: devkitpro/devkitarm:latest
+            docker_image: devkitpro/devkitarm:20251117
             run_test: "false"
             cmake_preset: nintendo-3ds-ninja-release
 
           - name: DevkitPro Switch
             os: ubuntu-24.04
-            docker_image: devkitpro/devkita64:latest
+            docker_image: devkitpro/devkita64:20251117
             run_test: "false"
             cmake_preset: nintendo-switch-ninja-release
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Migrate Docker builds to GitHub Actions native container support

- Remove custom docker-run-action in favor of container field

- Simplify CI workflow by using native container execution

- Conditionally skip preparation step for containerized jobs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflow"] -->|"Add container field"| B["Native Container Support"]
  A -->|"Remove docker-run-action"| C["Simplified Build Step"]
  A -->|"Conditional Prepare Step"| D["Skip for Containers"]
  B --> E["Unified Build Process"]
  C --> E
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_cmake.yaml</strong><dd><code>Migrate to native GitHub Actions container support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build_cmake.yaml

<ul><li>Added <code>container: ${{ matrix.docker_image }}</code> field to job configuration <br>for native container execution<br> <li> Added conditional check <code>if: ${{ matrix.docker_image == '' }}</code> to skip <br>"Prepare CI" step for containerized jobs<br> <li> Removed separate "Build and Test in Docker" step that used <br><code>addnab/docker-run-action@v3</code><br> <li> Consolidated Docker and native builds into single "Build and Test" <br>step</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/263/files#diff-bc3780103c5af571852278102dbe54fab038285c66bf73583e54bf3f659c73ca">+2/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

