### PR TITLE
ci: revert dependabot changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,3 @@ updates:
       - "dkrutskikh"
     commit-message:
       prefix: "chore: "
-
-  # Maintain Docker images used in GitHub Actions
-  - package-ecosystem: "docker"
-    directory: "/.github/workflows"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "dependabot"
-      - "dkrutskikh"
-    commit-message:
-      prefix: "chore: "


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Remove Docker image dependency updates from Dependabot configuration

- Revert to GitHub Actions-only dependency management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot Config"] -- "Remove Docker ecosystem" --> B["GitHub Actions only"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Remove Docker ecosystem from Dependabot updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Removed Docker package ecosystem configuration block<br> <li> Removed Docker directory path and schedule settings<br> <li> Removed Docker assignees and commit message prefix<br> <li> Retained GitHub Actions dependency update configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/264/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+0/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

