### PR TITLE
ci: update Xcode to 26.2.0 and DevkitPro containers to 20251231

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -25,12 +25,12 @@ jobs:
             cmake_preset: linux-ninja-release
 
           - name: macOS XCode arm64
-            os: macos-15
+            os: macos-26
             run_test: "true"
             cmake_preset: macos-xcode
 
           - name: macOS Ninja arm64
-            os: macos-15
+            os: macos-26
             run_test: "true"
             cmake_preset: macos-ninja-release
 
@@ -125,6 +125,8 @@ jobs:
             # Prefer the desired version if it exists, otherwise keep the default.
             if [ -d "/Applications/Xcode_26.2.0.app" ]; then
               sudo xcode-select -s /Applications/Xcode_26.2.0.app
+            elif [ -d "/Applications/Xcode_26.1.1.app" ]; then
+              sudo xcode-select -s /Applications/Xcode_26.1.1.app
             fi
           elif [[ "${{ matrix.os }}" =~ "ubuntu" ]]; then
             set -euo pipefail


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update macOS runner from macos-15 to macos-26

- Update DevkitPro container images to latest version

- Add fallback Xcode version selection for compatibility

- Improve Xcode version detection with multiple version checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Configuration"] -->|Update macOS| B["macos-26"]
  A -->|Update DevkitPro| C["devkitpro:20251231"]
  A -->|Enhance Xcode| D["Version Detection"]
  B --> E["XCode arm64 & Intel"]
  C --> F["GBA, NDS, 3DS, Switch"]
  D --> G["26.2.0 + 26.1.1 fallback"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_cmake.yaml</strong><dd><code>Update macOS runners and container versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build_cmake.yaml

<ul><li>Updated macOS runner OS from <code>macos-15</code> to <code>macos-26</code> for XCode and Ninja <br>builds<br> <li> Updated DevkitPro container images from <code>20251117</code> to <code>20251231</code> for GBA, <br>NDS, 3DS, and Switch builds<br> <li> Enhanced Xcode version selection to check for <code>Xcode_26.2.0.app</code> first, <br>then fallback to <code>Xcode_26.1.1.app</code><br> <li> Improved CI robustness with multiple Xcode version compatibility <br>checks</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/267/files#diff-bc3780103c5af571852278102dbe54fab038285c66bf73583e54bf3f659c73ca">+10/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

