### PR TITLE
wip

### DIFF
--- a/include/core/format.hpp
+++ b/include/core/format.hpp
@@ -93,7 +93,9 @@ public:
 
     \sa get()
   */
-  consteval explicit(false) FormatString(const CStringView & string) noexcept;
+  template <typename StringType>
+    requires std::convertible_to<StringType, CStringView>
+  consteval explicit(false) FormatString(StringType string) noexcept;
 
   /*!
     \brief Returns a copy of the stored format string.
@@ -147,6 +149,9 @@ private:
   */
   static void _compileTimeError(const char * message) noexcept;
 };
+
+template <typename StringType, class... Args>
+StringType & format(StringType & out, FormatString<Args...> formatString, Args &&... args);
 
 } // namespace toy
 

--- a/include/core/format.hpp
+++ b/include/core/format.hpp
@@ -153,6 +153,9 @@ private:
 template <typename StringType, class... Args>
 StringType & format(StringType & out, FormatString<Args...> formatString, Args &&... args);
 
+template <typename StringType, class... Args, size_t N>
+StringType & format(StringType & out, const char (&formatString)[N], Args &&... args);
+
 } // namespace toy
 
 #endif // INCLUDE_CORE_FORMAT_HPP_

--- a/include/core/format.inl
+++ b/include/core/format.inl
@@ -100,6 +100,12 @@ inline StringType & format(StringType & out, FormatString<Args...> formatString,
   return out;
 }
 
+template <typename StringType, class... Args, size_t N>
+inline StringType & format(StringType & out, const char (&formatString)[N], Args &&... args) {
+  constexpr FormatString<Args...> fs(formatString);
+  return format(out, fs, std::forward<Args>(args)...);
+}
+
 } // namespace toy
 
 #endif // INCLUDE_CORE_FORMAT_INL_

--- a/include/core/format.inl
+++ b/include/core/format.inl
@@ -28,8 +28,10 @@
 namespace toy {
 
 template <class... Args>
-consteval FormatString<Args...>::FormatString(const CStringView & string) noexcept
-  : _string(string) {
+template <typename StringType>
+  requires std::convertible_to<StringType, CStringView>
+consteval FormatString<Args...>::FormatString(StringType string) noexcept
+  : _string{string} {
   const auto placeholderCount = _countFormatPlaceholders(string);
   if (placeholderCount == CStringView::npos)
     _compileTimeError("Invalid format string: unmatched braces");
@@ -86,6 +88,16 @@ constexpr size_t FormatString<Args...>::_countFormatPlaceholders(const CStringVi
 template <class... Args>
 inline void FormatString<Args...>::_compileTimeError([[maybe_unused]] const char * message) noexcept {
   // Intentionally cause a compile-time error
+}
+
+template <typename StringType, class... Args>
+inline StringType & format(StringType & out, FormatString<Args...> formatString, Args &&... args) {
+  const auto expectedArgs = sizeof...(args);
+
+  if (expectedArgs > 0)
+    out = formatString.get().c_str();
+
+  return out;
 }
 
 } // namespace toy

--- a/test/core/format.test.cpp
+++ b/test/core/format.test.cpp
@@ -109,4 +109,31 @@ TEST_CASE("FormatString get method", "[core][format]") {
   }
 }
 
+TEST_CASE("format function", "[core][format]") {
+  SECTION("Format without arguments") {
+    FixedString<64> result;
+
+    constexpr FormatString<> formatStr("Hello World");
+    format(result, formatStr);
+    REQUIRE(result == "Hello World");
+
+    constexpr CStringView stringView("Hello World");
+    format(result, stringView);
+    REQUIRE(result == "Hello World");
+
+    format(result, "Hello World");
+    REQUIRE(result == "Hello World");
+  }
+
+  SECTION("Format with single integer argument") {
+    FixedString<64> result;
+    constexpr FormatString<int32_t> formatStr("Value: {}");
+
+    format(result, formatStr, 42);
+
+    REQUIRE(result == "Value: {}");
+    REQUIRE(result.size() == 9);
+  }
+}
+
 } // namespace toy


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Make FormatString constructor template-based for flexible string types

- Add template constraint using std::convertible_to for type safety

- Implement format() function template for output formatting

- Add comprehensive tests for format function behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FormatString Constructor"] -->|"Template with requires"| B["Accepts any StringType"]
  B -->|"Convertible to CStringView"| C["Type-safe conversion"]
  D["format() Function"] -->|"Template implementation"| E["Formats to output"]
  E -->|"Returns reference"| F["StringType&"]
  G["Test Cases"] -->|"Validates behavior"| H["Constructor & format()"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>format.hpp</strong><dd><code>Template-based constructor and format function declaration</code></dd></summary>
<hr>

include/core/format.hpp

<ul><li>Changed FormatString constructor from single CStringView parameter to <br>template accepting any StringType<br> <li> Added std::convertible_to constraint for type safety<br> <li> Added forward declaration of format() function template</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/273/files#diff-184c3b33976d5fae1fd410ee9e256006458d4d121b0179e2bce97ad5fc39df22">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>format.inl</strong><dd><code>Template constructor implementation and format function</code>&nbsp; &nbsp; </dd></summary>
<hr>

include/core/format.inl

<ul><li>Updated FormatString constructor implementation to use template <br>parameter StringType<br> <li> Added requires clause for std::convertible_to constraint<br> <li> Changed member initialization from copy to brace initialization<br> <li> Implemented format() function template that copies format string to <br>output</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/273/files#diff-66954126fd6d9d66189b601d945c7093b3065faa29d87ae8438bdf6ff173e60f">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>format.test.cpp</strong><dd><code>Add format function test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/core/format.test.cpp

<ul><li>Added new test case "format function" with two sections<br> <li> Tests format without arguments using FormatString, CStringView, and <br>string literal<br> <li> Tests format with single integer argument validation</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/273/files#diff-1dd1e2f710387ef74096a41782a2005badd7bf68af68a14f401628af71cad7cc">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

