### PR TITLE
feat: add FormatString const char* constructor overload

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,12 +1,17 @@
-# Documentation: https://releases.llvm.org/22.1.0/tools/clang/docs/ClangFormatStyleOptions.html#alignconsecutiveassignments
+# Documentation: https://releases.llvm.org/22.1.0/tools/clang/docs/ClangFormatStyleOptions.html#alignconsecutivebitfields
 ---
 Language: Cpp
 Standard: Latest
 AccessModifierOffset: -2
 AlignAfterOpenBracket: true
-AlignArrayOfStructures: Right,
+AlignArrayOfStructures: Right
 AlignConsecutiveAssignments:
-  Enabled: false
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+  AlignCompound: true
+  AlignFunctionPointers: false
+  PadOperators: true
 AlignConsecutiveDeclarations:
   Enabled: false
 AlignEscapedNewlines: Right

--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,7 @@ AlignArrayOfStructures: Right
 AlignConsecutiveAssignments:
   Enabled: true
   AcrossEmptyLines: true
-  AcrossComments: true
+  AcrossComments: false
   AlignCompound: true
   AlignFunctionPointers: false
   PadOperators: true

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -35,7 +35,7 @@ set(MSVC_C_FLAGS_RELEASE          "    /diagnostics:classic /sdl-               
 set(MSVC_CXX_FLAGS_RELEASE        "    /diagnostics:classic /sdl-                                      /Ox /Ob3 /Oi  /Ot /Oy  /GT /GL /DNDEBUG /GF                                    /MT  /GS- /guard:cf- /Gy- /Qpar  /fp:fast    /fp:except- /Gr")
 
 # Option Summary  https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Warning-Options.html
-#                 https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Warning-Options.html#index-Wif-not-aligned
+#                 https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Warning-Options.html#index-Wmissing-attributes
 # Option Summary  https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html
 
 set(GCC_C_FLAGS   "-std=c17   -Wall -Wextra -Wpedantic -Werror -Wfatal-errors -Wdouble-promotion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=2 -Winit-self                     -Wimplicit-fallthrough=5            -Wnull-dereference                                                                                                                                                                                     -Wextra-semi                                                                                                    -fstrict-flex-arrays=2")

--- a/include/core/format_string.hpp
+++ b/include/core/format_string.hpp
@@ -100,9 +100,33 @@ public:
     \note \c consteval; ill-formed patterns make the program ill-formed.
     \note Escaped \c {{ and \c }} are not placeholders.
 
+    \sa FormatString(const char *)
     \sa get()
   */
   consteval explicit(false) FormatString(const CStringView & string) noexcept;
+
+  /*!
+    \brief Validates \a string at compile time and stores it as a \ref toy::CStringView.
+
+    Convenience overload accepting a null-terminated C string directly, avoiding the two-step implicit conversion
+    through \ref toy::CStringView that would otherwise be needed at call sites.
+
+    \param string Null-terminated format pattern to validate and store.
+
+    \pre \a string is not null and is a valid null-terminated character sequence.
+    \pre Braces in \a string are balanced; \c {{ and \c }} are literals.
+    \pre Either: auto mode — number of \c {} equals \c sizeof...(Args); or positional mode — each \c {N} has \c N \c <
+         \c sizeof...(Args), and the pattern does not mix \c {} with \c {N}.
+
+    \post The pattern is stored and can be read with get().
+
+    \note \c consteval; ill-formed patterns make the program ill-formed.
+    \note Escaped \c {{ and \c }} are not placeholders.
+
+    \sa FormatString(const CStringView &)
+    \sa get()
+  */
+  consteval explicit(false) FormatString(const char * string) noexcept;
 
   /*!
     \brief Default copy constructor.

--- a/include/core/format_string.inl
+++ b/include/core/format_string.inl
@@ -58,6 +58,10 @@ consteval FormatString<Args...>::FormatString(const CStringView & string) noexce
 }
 
 template <class... Args>
+consteval FormatString<Args...>::FormatString(const char * string) noexcept
+  : FormatString(CStringView(string)) {}
+
+template <class... Args>
 constexpr CStringView FormatString<Args...>::get() const noexcept {
   return _string;
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `const char*` constructor overload to `FormatString` class

- Enables direct null-terminated C string usage without intermediate conversion

- Update clang-format configuration with alignment settings

- Fix documentation link reference in CMake compiler configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FormatString(const char*)"] -->|delegates to| B["FormatString(CStringView)"]
  B -->|validates and stores| C["Format pattern"]
  D["Clang-format config"] -->|alignment updates| E["Code formatting"]
  F["CMake config"] -->|doc link fix| G["GCC warning options"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>format_string.hpp</strong><dd><code>Add const char* constructor overload documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/core/format_string.hpp

<ul><li>Add new <code>consteval</code> constructor overload accepting <code>const char*</code> parameter<br> <li> Provide comprehensive documentation for the new overload with <br>preconditions and postconditions<br> <li> Add cross-reference (<code>\sa</code>) between both constructor overloads</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/366/files#diff-def31299b386745aac01402e0a897ba491d5e955c3e43d438369437b7dd2598f">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>format_string.inl</strong><dd><code>Implement const char* constructor delegation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/core/format_string.inl

<ul><li>Implement <code>const char*</code> constructor that delegates to <code>CStringView</code> <br>constructor<br> <li> Constructor creates temporary <code>CStringView</code> from raw pointer for <br>validation</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/366/files#diff-cc73936707b721af3a54f527a7c790c02826dc0005a5db86be2d4e571fb26eb7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConfigureCompiler.cmake</strong><dd><code>Fix GCC warning options documentation link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmake/ConfigureCompiler.cmake

<ul><li>Fix documentation URL reference from <code>Wif-not-aligned</code> to <br><code>Wmissing-attributes</code><br> <li> Correct GCC warning options documentation link</ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/366/files#diff-e65655878b2e7518b76a2b0a036285f2df3e0e0d5bcd32ff58b0b0790731fcc9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.clang-format</strong><dd><code>Update clang-format alignment configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.clang-format

<ul><li>Enable <code>AlignConsecutiveAssignments</code> with additional configuration <br>options<br> <li> Add <code>AcrossEmptyLines</code>, <code>AlignCompound</code>, and <code>PadOperators</code> settings<br> <li> Remove trailing comma from <code>AlignArrayOfStructures</code> value<br> <li> Update documentation URL reference to <code>alignconsecutivebitfields</code></ul>


</details>


  </td>
  <td><a href="https://github.com/ToymanInteractive/toygine2/pull/366/files#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

