### PR TITLE
feat(core): add runtime format support via vformat

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# Documentation: https://releases.llvm.org/22.1.0/tools/clang/docs/ClangFormatStyleOptions.html#alignconsecutivetablegendefinitioncolons
+# Documentation: https://releases.llvm.org/22.1.0/tools/clang/docs/ClangFormatStyleOptions.html#allowallargumentsonnextline
 ---
 Language: Cpp
 Standard: Latest
@@ -44,7 +44,10 @@ AlignConsecutiveTableGenDefinitionColons:
   AcrossComments: true
 AlignEscapedNewlines: Right
 AlignOperands: Align
-AlignTrailingComments: false
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 1
+  AlignPPAndNotPP: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false

--- a/benchmarks/core/format.benchmark.cpp
+++ b/benchmarks/core/format.benchmark.cpp
@@ -19,7 +19,7 @@
 //
 /*!
   \file   format.benchmark.cpp
-  \brief  Nanobench benchmarks for toy::makeVFormatArguments() and toy::vformatTo().
+  \brief  Nanobench benchmarks for toy::makeVFormatArguments(), toy::vformatTo(), and toy::vformat().
 */
 
 #include "../benchmark_factory.hpp"
@@ -239,6 +239,55 @@ void formatCoreBenchmarks(ankerl::nanobench::Bench & bench) noexcept {
     vformatTo(output, CStringView("{1} before {0}"), 10, 20);
 
     doNotOptimize(output);
+  });
+
+  // ----- vformat (array overload) -----
+
+  bench.run("vformat single int", [] {
+    const int x      = 42;
+    auto      args   = makeVFormatArguments(x);
+    auto      result = vformat<64>(CStringView("value: {}"), args);
+
+    doNotOptimize(result);
+  });
+
+  bench.run("vformat single c-string", [] {
+    const char * msg  = "hello";
+    auto         args = makeVFormatArguments(msg);
+    auto         result = vformat<64>(CStringView("say: {}"), args);
+
+    doNotOptimize(result);
+  });
+
+  bench.run("vformat 3 args mixed", [] {
+    const int    a    = 42;
+    const char * b    = "world";
+    const bool   c    = true;
+    auto         args = makeVFormatArguments(a, b, c);
+    auto         result = vformat<64>(CStringView("{} {} {}"), args);
+
+    doNotOptimize(result);
+  });
+
+  bench.run("vformat 5 args int", [] {
+    const int a    = 1;
+    const int b    = 2;
+    const int c    = 3;
+    const int d    = 4;
+    const int e    = 5;
+    auto      args   = makeVFormatArguments(a, b, c, d, e);
+    auto      result = vformat<128>(CStringView("{} {} {} {} {}"), args);
+
+    doNotOptimize(result);
+  });
+
+  bench.run("vformat positional reorder", [] {
+    const int a    = 10;
+    const int b    = 20;
+    auto      args   = makeVFormatArguments(a, b);
+    auto      result = vformat<64>(CStringView("{1} before {0}"), args);
+
+    doNotOptimize(result);
   });
 }
 

--- a/benchmarks/core/format.benchmark.cpp
+++ b/benchmarks/core/format.benchmark.cpp
@@ -252,29 +252,29 @@ void formatCoreBenchmarks(ankerl::nanobench::Bench & bench) noexcept {
   });
 
   bench.run("vformat single c-string", [] {
-    const char * msg  = "hello";
-    auto         args = makeVFormatArguments(msg);
+    const char * msg    = "hello";
+    auto         args   = makeVFormatArguments(msg);
     auto         result = vformat<64>(CStringView("say: {}"), args);
 
     doNotOptimize(result);
   });
 
   bench.run("vformat 3 args mixed", [] {
-    const int    a    = 42;
-    const char * b    = "world";
-    const bool   c    = true;
-    auto         args = makeVFormatArguments(a, b, c);
+    const int    a      = 42;
+    const char * b      = "world";
+    const bool   c      = true;
+    auto         args   = makeVFormatArguments(a, b, c);
     auto         result = vformat<64>(CStringView("{} {} {}"), args);
 
     doNotOptimize(result);
   });
 
   bench.run("vformat 5 args int", [] {
-    const int a    = 1;
-    const int b    = 2;
-    const int c    = 3;
-    const int d    = 4;
-    const int e    = 5;
+    const int a      = 1;
+    const int b      = 2;
+    const int c      = 3;
+    const int d      = 4;
+    const int e      = 5;
     auto      args   = makeVFormatArguments(a, b, c, d, e);
     auto      result = vformat<128>(CStringView("{} {} {} {} {}"), args);
 
@@ -282,8 +282,8 @@ void formatCoreBenchmarks(ankerl::nanobench::Bench & bench) noexcept {
   });
 
   bench.run("vformat positional reorder", [] {
-    const int a    = 10;
-    const int b    = 20;
+    const int a      = 10;
+    const int b      = 20;
     auto      args   = makeVFormatArguments(a, b);
     auto      result = vformat<64>(CStringView("{1} before {0}"), args);
 

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -35,7 +35,7 @@ set(MSVC_C_FLAGS_RELEASE          "    /diagnostics:classic /sdl-               
 set(MSVC_CXX_FLAGS_RELEASE        "    /diagnostics:classic /sdl-                                      /Ox /Ob3 /Oi  /Ot /Oy  /GT /GL /DNDEBUG /GF                                    /MT  /GS- /guard:cf- /Gy- /Qpar  /fp:fast    /fp:except- /Gr")
 
 # Option Summary  https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Warning-Options.html
-#                 https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Warning-Options.html#index-Wunused-value
+#                 https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Warning-Options.html#index-Wmaybe-uninitialized
 # Option Summary  https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html
 
 set(GCC_C_FLAGS   "-std=c17   -Wall -Wextra -Wpedantic -Werror                                           -Wdouble-promotion -Wextra-semi -Wfatal-errors -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=2 -Wimplicit-fallthrough=5 -Winit-self                                                  -Wnull-dereference                                                                                                                                                                                                                                                                 -fstrict-flex-arrays=2")

--- a/include/core/format.hpp
+++ b/include/core/format.hpp
@@ -113,14 +113,14 @@ constexpr void formatTo(BackendType & output, type_identity_t<FormatString<Args.
 
   \return A \ref toy::FixedString<BufferSize> containing the formatted result.
 
-  \pre \a pattern must be a valid format pattern consistent with \a MaxArgs.
+  \pre \a pattern must be a valid format pattern consistent with \a MaximumArgs.
   \pre Each \ref toy::FormatArgument in \a args must remain valid for the duration of the call.
 
   \note When the formatted result exceeds \a BufferSize characters the output is silently truncated per
         \ref toy::FixedString capacity semantics.
   \note Pattern validity is checked at runtime; use toy::format() for compile-time checks.
 
-  \sa toy::vformatTo(), toy::vformat(CStringView, const Args &...)
+  \sa toy::vformatTo(), toy::makeVFormatArguments()
 */
 template <size_t BufferSize, size_t MaximumArgs>
 [[nodiscard]] FixedString<BufferSize> vformat(CStringView                                pattern,

--- a/include/core/format.hpp
+++ b/include/core/format.hpp
@@ -100,6 +100,35 @@ constexpr void formatTo(BackendType & output, type_identity_t<FormatString<Args.
 /*!
   \ingroup String
 
+  \brief Formats type-erased arguments into a new \ref toy::FixedString using a runtime pattern.
+
+  Equivalent to creating a \ref toy::FixedString<BufferSize>, calling toy::vformatTo() into it, and returning the
+  result.
+
+  \tparam BufferSize  Capacity of the returned \ref toy::FixedString in bytes.
+  \tparam MaximumArgs Number of arguments; deduced from \a args.
+
+  \param pattern Runtime format pattern; may be a variable or computed string.
+  \param args    Type-erased arguments produced by toy::makeVFormatArguments().
+
+  \return A \ref toy::FixedString<BufferSize> containing the formatted result.
+
+  \pre \a pattern must be a valid format pattern consistent with \a MaxArgs.
+  \pre Each \ref toy::FormatArgument in \a args must remain valid for the duration of the call.
+
+  \note When the formatted result exceeds \a BufferSize characters the output is silently truncated per
+        \ref toy::FixedString capacity semantics.
+  \note Pattern validity is checked at runtime; use toy::format() for compile-time checks.
+
+  \sa toy::vformatTo(), toy::vformat(CStringView, const Args &...)
+*/
+template <size_t BufferSize, size_t MaximumArgs>
+[[nodiscard]] FixedString<BufferSize> vformat(CStringView                                pattern,
+                                              const array<FormatArgument, MaximumArgs> & args) noexcept;
+
+/*!
+  \ingroup String
+
   \brief Formats arguments into \a output using a runtime pattern, type-erasing them automatically.
 
   Iterates \a pattern, copies literal text to \a output verbatim, and substitutes each \c {} or \c {N} placeholder with

--- a/include/core/format.inl
+++ b/include/core/format.inl
@@ -161,6 +161,15 @@ constexpr void formatTo(BackendType & output, type_identity_t<FormatString<Args.
   output = stream.str();
 }
 
+template <size_t BufferSize, size_t MaximumArgs>
+FixedString<BufferSize> vformat(CStringView pattern, const array<FormatArgument, MaximumArgs> & args) noexcept {
+  FixedString<BufferSize> result;
+
+  vformatTo(result, pattern, args);
+
+  return result;
+}
+
 template <OStringStreamBackend BackendType, typename... Args>
 void vformatTo(BackendType & output, CStringView pattern, const Args &... args) noexcept {
   vformatTo(output, pattern, makeVFormatArguments(args...));

--- a/include/core/format.inl
+++ b/include/core/format.inl
@@ -19,7 +19,7 @@
 //
 /*!
   \file   format.inl
-  \brief  Inline implementations for toy::format() and toy::formatTo().
+  \brief  Inline implementations for toy::format(), toy::formatTo(), toy::vformat(), and toy::vformatTo().
 
   \note Included by core.hpp only; do not include this file directly.
 */

--- a/src/core/core.hpp.in
+++ b/src/core/core.hpp.in
@@ -74,8 +74,6 @@ using std::uint8_t;
 
 using std::byte;
 
-using std::nullptr_t;
-
 // (lvl 1)               Containers library https://en.cppreference.com/w/cpp/container.html
 
 // https://en.cppreference.com/w/cpp/container/array.html
@@ -97,6 +95,9 @@ using std::strong_ordering;
 using std::bit_cast;
 
 // (lvl 2) Type support (basic types, RTTI) https://en.cppreference.com/w/cpp/utility/rtti.html
+
+// https://en.cppreference.com/w/cpp/types/nullptr_t.html
+using std::nullptr_t;
 
 // https://en.cppreference.com/w/cpp/types/numeric_limits.html
 using std::numeric_limits;

--- a/tests/core/format.test.cpp
+++ b/tests/core/format.test.cpp
@@ -201,6 +201,42 @@ TEST_CASE("core/format_to/positional") {
   REQUIRE(output == "{12/2024}");
 }
 
+// ----- vformat (array overload) -----
+
+// Pattern from a runtime variable — the key differentiator from toy::format().
+TEST_CASE("core/vformat/runtime_pattern") {
+  // Build the pattern at runtime so it cannot be a compile-time FormatString.
+  FixedString<32> pattern;
+  pattern.append("x=");
+  pattern.append("{}");
+  const CStringView runtimePattern(pattern.c_str());
+
+  // Keep the original value alive for the duration of the array of FormatArgument object.
+  const int x      = 99;
+  auto      args   = makeVFormatArguments(x);
+  auto      result = vformat<32>(runtimePattern, args);
+
+  REQUIRE(result == "x=99");
+}
+
+// makeVFormatArguments with zero arguments produces an empty collection.
+TEST_CASE("core/vformat/make_vformat_args_empty") {
+  auto args = makeVFormatArguments();
+
+  REQUIRE(args.size() == 0);
+
+  const auto result = vformat<32>(CStringView("no args"), args);
+
+  REQUIRE(result == "no args");
+}
+
+// makeVFormatArguments returns arrays of the argument count.
+TEST_CASE("core/vformat/vformat_args_size") {
+  auto args = makeVFormatArguments(1, 2.0f, "three");
+
+  REQUIRE(args.size() == 3);
+}
+
 // ----- vformatTo (variadic overload) -----
 
 // Literal-only pattern is copied verbatim.

--- a/tests/core/format.test.cpp
+++ b/tests/core/format.test.cpp
@@ -211,7 +211,7 @@ TEST_CASE("core/vformat/runtime_pattern") {
   pattern.append("{}");
   const CStringView runtimePattern(pattern.c_str());
 
-  // Keep the original value alive for the duration of the array of FormatArgument object.
+  // Keep the original value alive for the duration of the FormatArgument array.
   const int x      = 99;
   auto      args   = makeVFormatArguments(x);
   auto      result = vformat<32>(runtimePattern, args);

--- a/tests/core/format.test.cpp
+++ b/tests/core/format.test.cpp
@@ -219,24 +219,6 @@ TEST_CASE("core/vformat/runtime_pattern") {
   REQUIRE(result == "x=99");
 }
 
-// makeVFormatArguments with zero arguments produces an empty collection.
-TEST_CASE("core/vformat/make_vformat_args_empty") {
-  auto args = makeVFormatArguments();
-
-  REQUIRE(args.size() == 0);
-
-  const auto result = vformat<32>(CStringView("no args"), args);
-
-  REQUIRE(result == "no args");
-}
-
-// makeVFormatArguments returns arrays of the argument count.
-TEST_CASE("core/vformat/vformat_args_size") {
-  auto args = makeVFormatArguments(1, 2.0f, "three");
-
-  REQUIRE(args.size() == 3);
-}
-
 // ----- vformatTo (variadic overload) -----
 
 // Literal-only pattern is copied verbatim.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime-formatting API overload that accepts prepared argument collections and returns formatted strings.

* **Tests**
  * Added a test validating runtime-pattern formatting using the new overload.

* **Benchmarks**
  * Added benchmarks for the array-based runtime-formatting across varied argument mixes.

* **Style**
  * Updated C++ formatting configuration to change trailing-comment alignment behavior.

* **Chores**
  * Minor comment/link and header-order cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->