### PR TITLE
ci: migrate to custom GBA toolchain

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -8,7 +8,8 @@ on:
       CODECOV_TOKEN:
         required: true
 
-permissions: {}
+permissions:
+  packages: read
 
 jobs:
   build:
@@ -64,7 +65,7 @@ jobs:
 
           - name: DevkitPro GBA
             os: ubuntu-24.04
-            container: devkitpro/devkitarm:20260221
+            container: ghcr.io/toymaninteractive/toygine2.gba.toolchain:latest
             run_test: "false"
             cmake_preset: nintendo-gba-ninja-release
 

--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -9,10 +9,13 @@ on:
         required: true
 
 permissions:
-  packages: read
+  contents: read
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   dispatcher:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,7 +11,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   dispatcher:
@@ -64,5 +63,8 @@ jobs:
     name: Build with CMake
     needs:
       - style
+    permissions:
+      contents: read
+      packages: read
     uses: ./.github/workflows/build_cmake.yaml
     secrets: inherit

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   build:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened workflow permissions to grant read access to package registries in CI across build, pull-request, and push workflows.
  * Switched the GBA build pipeline to a newer toolchain container image for updated build tooling and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->