### PR TITLE
feat(docker): add mGBA headless build stage to Dockerfile.gba

### DIFF
--- a/Dockerfile.gba
+++ b/Dockerfile.gba
@@ -10,6 +10,7 @@ RUN git clone https://github.com/mgba-emu/mgba.git /tmp/mgba \
  && cmake -S /tmp/mgba -B /tmp/mgba/build \
       -G Ninja \
       -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_HEADLESS=ON \
       -DBUILD_SDL=OFF \
       -DBUILD_QT=OFF \
       -DBUILD_LIBRETRO=OFF \

--- a/Dockerfile.gba
+++ b/Dockerfile.gba
@@ -1,4 +1,26 @@
+# --- Stage 1: mGBA builder ---
+FROM devkitpro/devkitarm:20260221 AS mgba-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates cmake ninja-build zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/mgba-emu/mgba.git /tmp/mgba \
+ && git -C /tmp/mgba checkout f8082d31fb3ef6af15226e74229d6a5aaec526c6 \
+ && cmake -S /tmp/mgba -B /tmp/mgba/build \
+      -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SDL=OFF \
+      -DBUILD_QT=OFF \
+      -DBUILD_LIBRETRO=OFF \
+      -DUSE_FFMPEG=OFF \
+      -DUSE_DISCORD_RPC=OFF \
+ && cmake --build /tmp/mgba/build --target mgba-headless
+
+# --- Stage 2: final image ---
 FROM devkitpro/devkitarm:20260221
+
+COPY --from=mgba-builder /tmp/mgba/build/mgba-headless /usr/local/bin/mgba-headless
 
 LABEL org.opencontainers.image.title="ToyGine2 GBA Toolchain"
 LABEL org.opencontainers.image.description="devkitARM toolchain for building ToyGine2 targeting GBA."

--- a/Dockerfile.gba
+++ b/Dockerfile.gba
@@ -5,8 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git ca-certificates cmake ninja-build zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/mgba-emu/mgba.git /tmp/mgba \
- && git -C /tmp/mgba checkout f8082d31fb3ef6af15226e74229d6a5aaec526c6 \
+ARG MGBA_COMMIT=f8082d31fb3ef6af15226e74229d6a5aaec526c6
+RUN mkdir -p /tmp/mgba \
+ && cd /tmp/mgba \
+ && git init -q \
+ && git remote add origin https://github.com/mgba-emu/mgba.git \
+ && git fetch --depth 1 origin "${MGBA_COMMIT}" \
+ && git checkout --detach FETCH_HEAD \
  && cmake -S /tmp/mgba -B /tmp/mgba/build \
       -G Ninja \
       -DCMAKE_BUILD_TYPE=Release \
@@ -16,7 +21,7 @@ RUN git clone https://github.com/mgba-emu/mgba.git /tmp/mgba \
       -DBUILD_LIBRETRO=OFF \
       -DUSE_FFMPEG=OFF \
       -DUSE_DISCORD_RPC=OFF \
- && cmake --build /tmp/mgba/build --target mgba-headless
+ && cmake --build /tmp/mgba/build --target mgba-headless --parallel "$(nproc)"
 
 # --- Stage 2: final image ---
 FROM devkitpro/devkitarm:20260221


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image build to include mgba-headless binary, making it available within the container environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->