### PR TITLE
chore: disable MSVC AddressSanitizer for Win32 builds

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -101,9 +101,10 @@ ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: FunctionCall
 DerivePointerAlignment: false
-# Documentation: https://releases.llvm.org/22.1.0/tools/clang/docs/ClangFormatStyleOptions.html#disableformat
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
+EnumTrailingComma: Insert
+# Documentation: https://releases.llvm.org/22.1.0/tools/clang/docs/ClangFormatStyleOptions.html#experimentalautodetectbinpacking
 FixNamespaceComments: true
 IncludeBlocks: Regroup
 IncludeCategories:

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -77,7 +77,7 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
       set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}   /hotpatch")
       set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /hotpatch")
 
-    elif (CMAKE_SIZEOF_VOID_P MATCHES "8")
+    elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
 
       set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}   /fsanitize=address")
       set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fsanitize=address")

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -79,8 +79,8 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
     elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
 
-      set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}   /fsanitize=address")
-      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fsanitize=address")
+      set(CMAKE_C_FLAGS_RELWITHDEBINFO   "${CMAKE_C_FLAGS_RELWITHDEBINFO}   /fsanitize=address")
+      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /fsanitize=address")
 
     endif ()
 

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -25,17 +25,17 @@ cmake_minimum_required(VERSION 3.31.0 FATAL_ERROR)
 set(MSVC_C_FLAGS   "/nologo /Wall /WX /wd4007 /wd4464 /wd4514 /wd4668 /wd4710 /wd4711 /wd4820 /wd4866 /wd5039 /wd5045 /wd5219 /DWIN32 /D_WINDOWS /DUNICODE /D_UNICODE /EHsc /Zc:wchar_t /Zc:forScope /Zc:inline /Zc:rvalueCast /GR- /permissive- /arch:SSE2")
 set(MSVC_CXX_FLAGS "/nologo /Wall /WX /wd4007 /wd4464 /wd4514 /wd4668 /wd4710 /wd4711 /wd4820 /wd4866 /wd5039 /wd5045 /wd5219 /DWIN32 /D_WINDOWS /DUNICODE /D_UNICODE /EHsc /Zc:wchar_t /Zc:forScope /Zc:inline /Zc:rvalueCast /GR- /permissive- /arch:SSE2")
 
-set(MSVC_C_FLAGS_DEBUG            "/ZI /diagnostics:caret   /sdl                     /Od /Ob0 /Oi-     /Oy-         /D_DEBUG /GF- /RTCc /D_ALLOW_RTCc_IN_STL /RTCsu /MTd /GS  /guard:cf- /Gy  /Qpar- /fp:strict  /fp:except  /Gd /MP")
-set(MSVC_CXX_FLAGS_DEBUG          "/ZI /diagnostics:caret   /sdl                     /Od /Ob0 /Oi-     /Oy-         /D_DEBUG /GF- /RTCc /D_ALLOW_RTCc_IN_STL /RTCsu /MTd /GS  /guard:cf- /Gy  /Qpar- /fp:strict  /fp:except  /Gd /MP")
+set(MSVC_C_FLAGS_DEBUG            "/ZI /diagnostics:caret   /sdl  /Od /Ob0 /Oi-     /Oy-         /D_DEBUG /GF- /RTCc /D_ALLOW_RTCc_IN_STL /RTCsu /MTd /GS  /guard:cf- /Gy  /Qpar- /fp:strict  /fp:except  /Gd /MP")
+set(MSVC_CXX_FLAGS_DEBUG          "/ZI /diagnostics:caret   /sdl  /Od /Ob0 /Oi-     /Oy-         /D_DEBUG /GF- /RTCc /D_ALLOW_RTCc_IN_STL /RTCsu /MTd /GS  /guard:cf- /Gy  /Qpar- /fp:strict  /fp:except  /Gd /MP")
 
-set(MSVC_C_FLAGS_RELWITHDEBINFO   "/Zi /diagnostics:column  /sdl  /fsanitize=address /Ox /Ob3 /Oi  /Ot /Oy- /GT /GL /D_DEBUG /GF                                    /MTd /GS  /guard:cf  /Gy- /Qpar- /fp:precise /fp:except  /Gr")
-set(MSVC_CXX_FLAGS_RELWITHDEBINFO "/Zi /diagnostics:column  /sdl  /fsanitize=address /Ox /Ob3 /Oi  /Ot /Oy- /GT /GL /D_DEBUG /GF                                    /MTd /GS  /guard:cf  /Gy- /Qpar- /fp:precise /fp:except  /Gr")
+set(MSVC_C_FLAGS_RELWITHDEBINFO   "/Zi /diagnostics:column  /sdl  /Ox /Ob3 /Oi  /Ot /Oy- /GT /GL /D_DEBUG /GF                                    /MTd /GS  /guard:cf  /Gy- /Qpar- /fp:precise /fp:except  /Gr")
+set(MSVC_CXX_FLAGS_RELWITHDEBINFO "/Zi /diagnostics:column  /sdl  /Ox /Ob3 /Oi  /Ot /Oy- /GT /GL /D_DEBUG /GF                                    /MTd /GS  /guard:cf  /Gy- /Qpar- /fp:precise /fp:except  /Gr")
 
-set(MSVC_C_FLAGS_RELEASE          "    /diagnostics:classic /sdl-                    /Ox /Ob3 /Oi  /Ot /Oy  /GT /GL /DNDEBUG /GF                                    /MT  /GS- /guard:cf- /Gy- /Qpar  /fp:fast    /fp:except- /Gr")
-set(MSVC_CXX_FLAGS_RELEASE        "    /diagnostics:classic /sdl-                    /Ox /Ob3 /Oi  /Ot /Oy  /GT /GL /DNDEBUG /GF                                    /MT  /GS- /guard:cf- /Gy- /Qpar  /fp:fast    /fp:except- /Gr")
+set(MSVC_C_FLAGS_RELEASE          "    /diagnostics:classic /sdl- /Ox /Ob3 /Oi  /Ot /Oy  /GT /GL /DNDEBUG /GF                                    /MT  /GS- /guard:cf- /Gy- /Qpar  /fp:fast    /fp:except- /Gr")
+set(MSVC_CXX_FLAGS_RELEASE        "    /diagnostics:classic /sdl- /Ox /Ob3 /Oi  /Ot /Oy  /GT /GL /DNDEBUG /GF                                    /MT  /GS- /guard:cf- /Gy- /Qpar  /fp:fast    /fp:except- /Gr")
 
 # Option Summary  https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Warning-Options.html
-#                 https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Warning-Options.html#index-Winvalid-utf8
+#                 https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Warning-Options.html#index-Wvla
 # Option Summary  https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html
 
 set(GCC_C_FLAGS   "-std=c17   -Wall -Wextra -Wpedantic -Werror -Walloca -Walloc-zero -Warray-bounds=2 -Wattribute-alias=2 -Wbad-function-cast -Wcast-align=strict -Wcast-qual                                           -Wconversion -Wdate-time -Wdouble-promotion -Wduplicated-branches -Wduplicated-cond -Wextra-semi -Wfatal-errors -Wfloat-equal -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wimplicit-fallthrough=5 -Winit-self                                   -Wlogical-op                                          -Wmissing-noreturn -Wmissing-prototypes -Wnested-externs            -Wnormalized=nfc -Wnull-dereference                                         -Wpacked                   -Wredundant-decls                  -Wshadow=local                                     -Wstrict-flex-arrays -Wstringop-overflow=3 -Wsuggest-attribute=noreturn                                                                                -Wtrampolines -Wundef -Wunused-macros -Wunknown-pragmas                                   -Wwrite-strings                                 -fstrict-flex-arrays=2")
@@ -74,8 +74,13 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
     if (CMAKE_SIZEOF_VOID_P MATCHES "4")
 
-      set(CMAKE_C_FLAGS_DEBUG   "${MSVC_C_FLAGS_DEBUG}   /hotpatch")
-      set(CMAKE_CXX_FLAGS_DEBUG "${MSVC_CXX_FLAGS_DEBUG} /hotpatch")
+      set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}   /hotpatch")
+      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /hotpatch")
+
+    elif (CMAKE_SIZEOF_VOID_P MATCHES "8")
+
+      set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}   /fsanitize=address")
+      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fsanitize=address")
 
     endif ()
 
@@ -99,8 +104,8 @@ elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Linux Desktop")
     message(FATAL_ERROR "GCC >= 13.3 required")
   endif ()
 
-  set(CMAKE_C_FLAGS   "${GCC_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${GCC_CXX_FLAGS}")
+  set(CMAKE_C_FLAGS   "${GCC_C_FLAGS}   -Wvector-operation-performance")
+  set(CMAKE_CXX_FLAGS "${GCC_CXX_FLAGS} -Wvector-operation-performance")
 
   set(CMAKE_C_FLAGS_DEBUG                   "${GCC_C_FLAGS_DEBUG}")
   set(CMAKE_CXX_FLAGS_DEBUG                 "${GCC_CXX_FLAGS_DEBUG}")

--- a/include/core/format_pattern.hpp
+++ b/include/core/format_pattern.hpp
@@ -56,7 +56,7 @@ enum class FormatPatternValidationError {
   argCountMismatch,
 
   /// Positional index out of range or overflow while parsing digits.
-  indexOutOfRange
+  indexOutOfRange,
 };
 
 /*!

--- a/include/core/format_pattern.inl
+++ b/include/core/format_pattern.inl
@@ -42,7 +42,7 @@ enum class PlaceholderMode {
   autoIndex,
 
   /// Only positional \c {N} placeholders appear in the pattern.
-  positional
+  positional,
 };
 
 /*!

--- a/include/platform/ui/window_style.hpp
+++ b/include/platform/ui/window_style.hpp
@@ -61,7 +61,7 @@ enum class WindowStyle : uint8_t {
   FullScreen = 0x10,
 
   /// Window has been resized.
-  Resized = 0x20
+  Resized = 0x20,
 };
 
 } // namespace toy::platform::ui

--- a/tests/core/bitwise_enum.test.cpp
+++ b/tests/core/bitwise_enum.test.cpp
@@ -32,7 +32,7 @@ enum class TestFlags : uint8_t {
   None = 0,
   A    = 1,
   B    = 2,
-  C    = 4
+  C    = 4,
 };
 
 } // namespace toy

--- a/tests/gba_filtering_stream_buf.hpp
+++ b/tests/gba_filtering_stream_buf.hpp
@@ -61,7 +61,7 @@ private:
   enum class State {
     Normal,
     Escape,
-    Csi
+    Csi,
   };
 
   State _state{State::Normal};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated compiler configuration: tightened MSVC flag formatting, adjusted how debug flags are composed, and enabled address sanitizer for 64-bit RelWithDebInfo builds.
  * Added a new GCC warning (-Wvector-operation-performance) to Linux builds.
  * Updated formatting rules to insert trailing commas for enums and added an experimental config comment block.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToymanInteractive/toygine2/pull/418)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->