### PR TITLE
chore: remove Dependabot from Dependabot update assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
       interval: "daily"
 
     assignees:
-      - "dependabot"
       - "dkrutskikh"
 
     commit-message:


### PR DESCRIPTION
Removed 'dependabot' from assignees in dependabot.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automatic dependency update assignment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->