### PR TITLE
ci: add CMake build workflow for main pushes

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -70,12 +70,6 @@ jobs:
             run_test: "true"
             cmake_preset: linux-release
 
-          - name: Sega Mega Drive / Genesis
-            os: ubuntu-26.04
-            container: ghcr.io/toymaninteractive/toygine2.md.toolchain:latest
-            run_test: "false"
-            cmake_preset: md-release
-
           - name: Nintendo GBA
             os: ubuntu-26.04
             container: ghcr.io/toymaninteractive/toygine2.gba.toolchain:latest

--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -11,8 +11,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-      pull-requests: write
-      checks: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -70,6 +70,12 @@ jobs:
             run_test: "true"
             cmake_preset: linux-release
 
+          - name: Sega Mega Drive / Genesis
+            os: ubuntu-26.04
+            container: ghcr.io/toymaninteractive/toygine2.md.toolchain:latest
+            run_test: "false"
+            cmake_preset: md-release
+
           - name: Nintendo GBA
             os: ubuntu-26.04
             container: ghcr.io/toymaninteractive/toygine2.gba.toolchain:latest
@@ -120,3 +126,7 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+
+      - name: Prepare APT staging dir
+        if: contains(matrix.os, 'ubuntu') && matrix.container == ''
+        run: mkdir -p "$RUNNER_TEMP/apt-cache"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,20 @@
+name: Push
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build:
+    name: Build using CMake
+    uses: ./.github/workflows/build_cmake.yaml
+    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,7 +244,7 @@ Doxygen is the only documentation system here: this section covers what a block 
 * **Doxygen commands over raw markup:** Markdown sparingly, never HTML — the XML output feeds the documentation site. Which command marks what is **Documentation Style Rules**.
 * **Mark up by kind, not by emphasis:** `\a` parameters, `\c` literals, `\ref` non-function symbols, plain `toy::function()` for functions (see **Parameter Documentation**, **Cross-References**). **Bold** only for the lead term of a `\section` bullet; section bodies are plain text.
 * **Present tense, active voice:** "Returns the element count", not "Will return" or "The count is returned"; a `\param` is a noun phrase, not a sentence about the caller.
-* **Do not restate the signature:** a block says what the declaration cannot. Never open a `\brief` with the symbol's name — nor a `\file` block with the file name — nor spell out a visible type.
+* **Do not restate the signature:** a block says what the declaration cannot. Never open a `\brief` with the symbol's name — in a `\file` block, with the file name the `\file` tag already carries — nor spell out a visible type.
 * **One fact per tag:** one line per `\note`, `\warning` only for what breaks a caller, 2-3 `\sa` links at most (see **Notes and Warnings**, **See-Also Tags**).
 * **No abbreviations** beyond the domain terms the code uses (see Naming under **Code Quality**).
 * **Examples compile:** a `\section usage` block builds as written, lifted from a sample or a test, never from memory (see Documented and demonstrated under **API Design Principles**).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,19 @@ Doxygen is the only documentation system here: this section covers what a block 
 * **Macros:** a block directly above the `#define`; `\def` only where it cannot sit there (a macro is never a `\ref` target — see **Cross-References**).
 * **One block per namespace:** the `\namespace` description lives in the module barrel (`core.hpp` carries `\namespace toy`); Doxygen merges duplicates silently, so a second one elsewhere is invisible until it wins.
 
+### Writing Style
+
+* **Bullets over paragraphs** for independent facts; concision, neutrality, and terminology follow **Documentation Tone**.
+* **One-sentence `\brief`, then a blank line:** it must read alone in an index. The detailed description never repeats it — 1-2 sentences on a function, 2-4 on a type, none when the `\brief` suffices.
+* **No filler openings:** not "This function …", "A class that …", "Used to …" — start with the verb or the noun.
+* **Doxygen commands over raw markup:** Markdown sparingly, never HTML — the XML output feeds the documentation site. Which command marks what is **Documentation Style Rules**.
+* **Mark up by kind, not by emphasis:** `\a` parameters, `\c` literals, `\ref` non-function symbols, plain `toy::function()` for functions (see **Parameter Documentation**, **Cross-References**). **Bold** only for the lead term of a `\section` bullet; section bodies are plain text.
+* **Present tense, active voice:** "Returns the element count", not "Will return" or "The count is returned"; a `\param` is a noun phrase, not a sentence about the caller.
+* **Do not restate the signature:** a block says what the declaration cannot. Never open a `\brief` with the symbol's name — nor a `\file` block with the file name — nor spell out a visible type.
+* **One fact per tag:** one line per `\note`, `\warning` only for what breaks a caller, 2-3 `\sa` links at most (see **Notes and Warnings**, **See-Also Tags**).
+* **No abbreviations** beyond the domain terms the code uses (see Naming under **Code Quality**).
+* **Examples compile:** a `\section usage` block builds as written, lifted from a sample or a test, never from memory (see Documented and demonstrated under **API Design Principles**).
+
 ---
 
 ## Header / Source Organization

--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ ToyGine2 is a modern C++ high‑level engine for Retro-Style games.
 ## Requirements
 
 `ToyGine2` requires a C++23-compliant compiler. The following tools and compilers are supported
+
+### Tools
+
+- CMake 3.27 or newer
+- Doxygen 1.17+ and Graphviz (for documentation)
+- ClangFormat 22.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD**
  * Added an automated workflow to build changes pushed to the main branch.
  * Improved build setup reliability on Ubuntu runners.
  * Restricted workflow permissions to read-only access and automatically cancels superseded runs.

* **Documentation**
  * Added minimum required versions for CMake, Doxygen, Graphviz, and ClangFormat.
  * Added concise, neutral documentation style guidelines, including Doxygen conventions and compilable examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->