### PR TITLE
build(cmake): add release presets and report compiler flags

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -336,3 +336,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+
+      - name: Prepare APT staging dir
+        run: mkdir -p "$RUNNER_TEMP/apt-cache"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -940,6 +940,22 @@
             "output": {
                 "verbose": false
             }
+        },
+        {
+            "name": "default-release",
+            "hidden": true,
+            "inherits": "default",
+            "configurations": [
+                "RelWithDebInfo"
+            ]
+        },
+        {
+            "name": "default-shipping",
+            "hidden": true,
+            "inherits": "default",
+            "configurations": [
+                "Release"
+            ]
         }
     ]
 }

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -28,7 +28,7 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
   # MSVC Compiler Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/compiler-options-listed-by-category?view=msvc-170#optimization
-  # last option is /Oy
+  # last option is /arch
 
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
@@ -63,21 +63,27 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
     if (CMAKE_VS_PLATFORM_NAME STREQUAL "x64")
 
-      set(CMAKE_C_FLAGS_RELWITHDEBINFO          "${CMAKE_C_FLAGS_RELWITHDEBINFO}   /dynamicdeopt:sync /favor:blend")
-      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO        "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /dynamicdeopt:sync /favor:blend")
+      string(APPEND CMAKE_C_FLAGS   " /arch:SSE2")
+      string(APPEND CMAKE_CXX_FLAGS " /arch:SSE2")
 
-      set(CMAKE_C_FLAGS_RELEASE                 "${CMAKE_C_FLAGS_RELEASE}                             /favor:blend")
-      set(CMAKE_CXX_FLAGS_RELEASE               "${CMAKE_CXX_FLAGS_RELEASE}                           /favor:blend")
+      string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          " /dynamicdeopt:sync /favor:blend")
+      string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        " /dynamicdeopt:sync /favor:blend")
 
-      set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /DYNAMICDEOPT:SYNC")
+      string(APPEND CMAKE_C_FLAGS_RELEASE                 "                    /favor:blend")
+      string(APPEND CMAKE_CXX_FLAGS_RELEASE               "                    /favor:blend")
+
+      string(APPEND CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO " /DYNAMICDEOPT:SYNC")
 
     elseif (CMAKE_VS_PLATFORM_NAME STREQUAL "Win32")
 
-      set(CMAKE_C_FLAGS_RELWITHDEBINFO          "${CMAKE_C_FLAGS_RELWITHDEBINFO}    /favor:blend")
-      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO        "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}  /favor:blend")
+      string(APPEND CMAKE_C_FLAGS   " /arch:SSE2")
+      string(APPEND CMAKE_CXX_FLAGS " /arch:SSE2")
 
-      set(CMAKE_C_FLAGS_RELEASE                 "${CMAKE_C_FLAGS_RELEASE}           /favor:blend")
-      set(CMAKE_CXX_FLAGS_RELEASE               "${CMAKE_CXX_FLAGS_RELEASE}         /favor:blend")
+      string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          "                    /favor:blend")
+      string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        "                    /favor:blend")
+
+      string(APPEND CMAKE_C_FLAGS_RELEASE                 "                    /favor:blend")
+      string(APPEND CMAKE_CXX_FLAGS_RELEASE               "                    /favor:blend")
 
     elseif (CMAKE_VS_PLATFORM_NAME STREQUAL "ARM64")
 

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -33,9 +33,6 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
 
-
-    message(STATUS "Compiler: MSVC, version: " ${MSVC_VERSION})
-
     set(CMAKE_C_FLAGS                  "")
     set(CMAKE_CXX_FLAGS                "")
 

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -93,15 +93,11 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
 elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Linux Desktop")
 
-  message(STATUS "${CMAKE_CXX_COMPILER_ID} version: ${CMAKE_CXX_COMPILER_VERSION}")
-
 elseif (TOYGINE_TARGET_PLATFORM STREQUAL "macOS Desktop")
 
   if (CMAKE_GENERATOR STREQUAL "Xcode")
     message(STATUS "Compiler: Xcode, version: " ${XCODE_VERSION})
   endif ()
-
-  message(STATUS "${CMAKE_CXX_COMPILER_ID} version: ${CMAKE_CXX_COMPILER_VERSION}")
 
 elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Sega MD")
 
@@ -109,15 +105,11 @@ elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Sega MD")
     message(FATAL_ERROR "ClownMDSDK not found. Install ClownMDSDK and ensure CLOWNMDSDK is set.")
   endif ()
 
-  message(STATUS "${CMAKE_CXX_COMPILER_ID} version: ${CMAKE_CXX_COMPILER_VERSION}")
-
 elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo GBA")
 
   if (NOT DEVKITPRO_FOUND)
     message(FATAL_ERROR "devkitPro not found. Install devkitPro and ensure DEVKITPRO is set.")
   endif ()
-
-  message(STATUS "${CMAKE_CXX_COMPILER_ID} version: ${CMAKE_CXX_COMPILER_VERSION}")
 
 elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo DS")
 
@@ -125,23 +117,17 @@ elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo DS")
     message(FATAL_ERROR "devkitPro not found. Install devkitPro and ensure DEVKITPRO is set.")
   endif ()
 
-  message(STATUS "${CMAKE_CXX_COMPILER_ID} version: ${CMAKE_CXX_COMPILER_VERSION}")
-
 elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo 3DS")
 
   if (NOT DEVKITPRO_FOUND)
     message(FATAL_ERROR "devkitPro not found. Install devkitPro and ensure DEVKITPRO is set.")
   endif ()
 
-  message(STATUS "${CMAKE_CXX_COMPILER_ID} version: ${CMAKE_CXX_COMPILER_VERSION}")
-
 elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo Switch")
 
   if (NOT DEVKITPRO_FOUND)
     message(FATAL_ERROR "devkitPro not found. Install devkitPro and ensure DEVKITPRO is set.")
   endif ()
-
-  message(STATUS "${CMAKE_CXX_COMPILER_ID} version: ${CMAKE_CXX_COMPILER_VERSION}")
 
 elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo 64")
 
@@ -154,21 +140,48 @@ elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo GameCube")
     message(FATAL_ERROR "devkitPro not found. Install devkitPro and ensure DEVKITPRO is set.")
   endif ()
 
-  message(STATUS "${CMAKE_CXX_COMPILER_ID} version: ${CMAKE_CXX_COMPILER_VERSION}")
-
 elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo Wii")
 
   if (NOT DEVKITPRO_FOUND)
     message(FATAL_ERROR "devkitPro not found. Install devkitPro and ensure DEVKITPRO is set.")
   endif ()
 
-  message(STATUS "${CMAKE_CXX_COMPILER_ID} version: ${CMAKE_CXX_COMPILER_VERSION}")
-
 else ()
 
   message(FATAL_ERROR "Unsupported platform: ${TOYGINE_TARGET_PLATFORM}")
 
 endif ()
+
+message(STATUS "${CMAKE_CXX_COMPILER_ID} version: ${CMAKE_CXX_COMPILER_VERSION}")
+
+# Report the compiler and linker option variables, per configuration
+if (CMAKE_CONFIGURATION_TYPES)
+  set(REPORTED_CONFIGS ${CMAKE_CONFIGURATION_TYPES})
+elseif (CMAKE_BUILD_TYPE)
+  set(REPORTED_CONFIGS ${CMAKE_BUILD_TYPE})
+else ()
+  set(REPORTED_CONFIGS "")
+endif ()
+
+foreach (FLAGS_VARIABLE IN ITEMS
+  CMAKE_C_FLAGS
+  CMAKE_CXX_FLAGS
+  CMAKE_STATIC_LINKER_FLAGS
+  CMAKE_SHARED_LINKER_FLAGS
+  CMAKE_MODULE_LINKER_FLAGS
+  CMAKE_EXE_LINKER_FLAGS)
+
+  message(STATUS "${FLAGS_VARIABLE}: ${${FLAGS_VARIABLE}}")
+
+  foreach (REPORTED_CONFIG IN LISTS REPORTED_CONFIGS)
+    string(TOUPPER ${REPORTED_CONFIG} REPORTED_CONFIG_UPPER)
+    message(STATUS "${FLAGS_VARIABLE}_${REPORTED_CONFIG_UPPER}: ${${FLAGS_VARIABLE}_${REPORTED_CONFIG_UPPER}}")
+  endforeach ()
+
+endforeach ()
+
+unset(REPORTED_CONFIG_UPPER)
+unset(REPORTED_CONFIGS)
 
 if (ToyGine2_VERSION_MAJOR)
   add_compile_definitions(TOYGINE_VERSION_MAJOR=${ToyGine2_VERSION_MAJOR})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release and shipping package presets for streamlined build packaging.
  * Added SSE2 architecture flags for supported Windows builds.

* **Improvements**
  * Improved compiler configuration reporting, including active build settings and compiler versions.
  * Updated MSVC option documentation for greater accuracy.

* **Build & Validation**
  * Improved build setup reliability by staging an APT cache during analysis workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->