### PR TITLE
build(samples): install console sample into samples component

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -348,3 +348,32 @@ jobs:
           key: sonar-cloud-apt
           restore-keys: |
             sonar-cloud-apt
+
+      - name: Prepare CI
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+
+          APT_CACHE="${APT_CACHE:-${RUNNER_TEMP:-/tmp}/apt-cache}"
+          sudo mkdir -p "$APT_CACHE"
+
+          sudo apt -yq -o Acquire::Retries=3 update
+          sudo apt -yq \
+            -o Dir::Cache::archives="$APT_CACHE" \
+            -o APT::Keep-Downloaded-Packages=true \
+            -o Acquire::Retries=3 -o Dpkg::Use-Pty=0 \
+            install eatmydata
+
+          sudo eatmydata apt -yq --no-install-recommends \
+            -o Dir::Cache::archives="$APT_CACHE" \
+            -o APT::Keep-Downloaded-Packages=true \
+            -o Acquire::Retries=3 -o Dpkg::Use-Pty=0 \
+            install \
+            gcc-16 g++-16
+
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-16 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-16 100
+
+          sudo rm -f  "$APT_CACHE/lock" || true
+          sudo rm -rf "$APT_CACHE/partial" || true
+          sudo chown -R "$USER:$USER" "$APT_CACHE"

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -28,7 +28,7 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
   # MSVC Compiler Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/compiler-options-listed-by-category?view=msvc-170#optimization
-  # last option is /EHsc
+  # last option is /forceInterlockedFunctions
 
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
@@ -83,6 +83,9 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
       string(APPEND CMAKE_CXX_FLAGS_RELEASE               "                    /favor:blend")
 
     elseif (CMAKE_VS_PLATFORM_NAME STREQUAL "ARM64")
+
+      string(APPEND CMAKE_C_FLAGS   " /forceInterlockedFunctions")
+      string(APPEND CMAKE_CXX_FLAGS " /forceInterlockedFunctions")
 
     endif ()
 

--- a/samples/console/CMakeLists.txt
+++ b/samples/console/CMakeLists.txt
@@ -21,3 +21,5 @@
 add_executable(console_sample_app console_sample_app.cpp)
 
 target_link_libraries(console_sample_app PRIVATE toygine)
+
+install(TARGETS console_sample_app RUNTIME DESTINATION bin COMPONENT samples)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The console sample application is now included in installations under the `bin/samples` directory.

- **Bug Fixes**
  - Improved ARM64 build compatibility for projects using interlocked operations.
  - Updated build configuration to support newer compiler toolchains and more reliable continuous integration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->