### PR TITLE
build(cpack): package library, headers, and license into a ZIP

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -377,3 +377,10 @@ jobs:
           sudo rm -f  "$APT_CACHE/lock" || true
           sudo rm -rf "$APT_CACHE/partial" || true
           sudo chown -R "$USER:$USER" "$APT_CACHE"
+
+      - name: APT cache save
+        if: steps.sonar-cloud-apt-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ runner.temp }}/apt-cache
+          key: ${{ steps.sonar-cloud-apt-cache.outputs.cache-primary-key }}

--- a/.github/workflows/check_code_documentation.yaml
+++ b/.github/workflows/check_code_documentation.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y graphviz
-          curl --fail -L https://github.com/doxygen/doxygen/releases/download/Release_1_17_0/doxygen-1.17.0.linux.bin.tar.gz -o doxygen.tar.gz || { echo "Failed to download Doxygen"; exit 1; }
+          curl --fail -L https://github.com/doxygen/doxygen/releases/download/Release_1_18_0/doxygen-1.18.0.linux.bin.tar.gz -o doxygen.tar.gz || { echo "Failed to download Doxygen"; exit 1; }
           tar -xzf doxygen.tar.gz || { echo "Failed to extract Doxygen"; exit 1; }
           cd doxygen-*
           sudo cp bin/doxygen /usr/local/bin/ || { echo "Failed to install Doxygen"; exit 1; }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,27 @@ endif ()
 target_link_libraries(${TOYGINE_LIBRARY_NAME} ${LIB_LIST})
 
 #-----------------------------------------------------------------------------------------------------------------------
+# Installation
+#-----------------------------------------------------------------------------------------------------------------------
+
+# Only a top-level build installs. The engine exports no CMake package yet, so these rules exist to feed CPack (see
+# Packaging below); a parent project embedding toygine keeps its own install layout untouched.
+if (TOP_PROJECT)
+  install(TARGETS ${TOYGINE_LIBRARY_NAME}
+    ARCHIVE DESTINATION lib
+    COMPONENT library)
+
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION include
+    COMPONENT headers
+    FILES_MATCHING PATTERN "*.hpp" PATTERN "*.inl")
+
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
+    DESTINATION .
+    COMPONENT license)
+endif ()
+
+#-----------------------------------------------------------------------------------------------------------------------
 # Benchmarks
 #-----------------------------------------------------------------------------------------------------------------------
 
@@ -144,4 +165,45 @@ endif ()
 if (TOYGINE_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)
+endif ()
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Packaging
+#-----------------------------------------------------------------------------------------------------------------------
+
+# Packs whatever the build installed: the library, its headers and the license. The 'runtime' component arrives with the
+# sample install rules. include(CPack) must stay last, after every install() rule, otherwise the component list it
+# captures is incomplete.
+if (TOP_PROJECT)
+  set(CPACK_GENERATOR "ZIP")
+  set(CPACK_PACKAGE_NAME "${PROJECT_NAME}${PACKAGE_NAME_SUFFIX}")
+  set(CPACK_PACKAGE_VENDOR "Toyman Interactive")
+  set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+  set(CPACK_PACKAGE_HOMEPAGE_URL ${PROJECT_HOMEPAGE_URL})
+  set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ToyGine 2 static library, headers and samples")
+  set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+  # Component install mode is what filters the archive down to CPACK_COMPONENTS_ALL: without it CPack packs every
+  # install() rule in the build, including those the FetchContent dependencies declare for themselves. Grouping puts
+  # the components back into a single archive instead of one per component.
+  set(CPACK_COMPONENTS_ALL headers library license)
+  set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+  set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
+
+  # Component mode reads this one instead of CPACK_INCLUDE_TOPLEVEL_DIRECTORY, and defaults it off: unpacking would
+  # spill include/, lib/ and LICENSE into the current directory.
+  set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY ON)
+  set(CPACK_VERBATIM_VARIABLES ON)
+
+  # PACKAGE_FILE_NAME arrives from CI through the preset ($env{BUILD_FILE_NAME}) and carries the configuration and the
+  # commit, for example 'linux-x64-a131ded'. Project name and version are prepended here because CI cannot read them
+  # out of project(). Local builds get a descriptive name instead.
+  if (PACKAGE_FILE_NAME)
+    set(_base_name "${CPACK_PACKAGE_NAME}-${PROJECT_VERSION}-${PACKAGE_FILE_NAME}")
+  else ()
+    set(_base_name "${CPACK_PACKAGE_NAME}-${PROJECT_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+  endif ()
+
+  set(CPACK_PACKAGE_FILE_NAME "${_base_name}")
+
+  include(CPack)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,27 +114,6 @@ endif ()
 target_link_libraries(${TOYGINE_LIBRARY_NAME} ${LIB_LIST})
 
 #-----------------------------------------------------------------------------------------------------------------------
-# Installation
-#-----------------------------------------------------------------------------------------------------------------------
-
-# Only a top-level build installs. The engine exports no CMake package yet, so these rules exist to feed CPack (see
-# Packaging below); a parent project embedding toygine keeps its own install layout untouched.
-if (TOP_PROJECT)
-  install(TARGETS ${TOYGINE_LIBRARY_NAME}
-    ARCHIVE DESTINATION lib
-    COMPONENT library)
-
-  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
-    DESTINATION include
-    COMPONENT headers
-    FILES_MATCHING PATTERN "*.hpp" PATTERN "*.inl")
-
-  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
-    DESTINATION .
-    COMPONENT license)
-endif ()
-
-#-----------------------------------------------------------------------------------------------------------------------
 # Benchmarks
 #-----------------------------------------------------------------------------------------------------------------------
 
@@ -165,6 +144,25 @@ endif ()
 if (TOYGINE_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)
+endif ()
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Installation
+#-----------------------------------------------------------------------------------------------------------------------
+
+# Only a top-level build installs. The engine exports no CMake package yet, so these rules exist to feed CPack (see
+# Packaging below); a parent project embedding toygine keeps its own install layout untouched.
+if (TOP_PROJECT)
+  install(TARGETS ${TOYGINE_LIBRARY_NAME} ARCHIVE DESTINATION lib COMPONENT library)
+
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION include
+    COMPONENT headers
+    FILES_MATCHING PATTERN "*.hpp" PATTERN "*.inl")
+
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
+    DESTINATION .
+    COMPONENT license)
 endif ()
 
 #-----------------------------------------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ ToyGine2 is a modern C++ high‑level engine for Retro-Style games.
 ### Tools
 
 - CMake 3.27 or newer
-- Doxygen 1.17+ and Graphviz (for documentation)
+- Doxygen 1.18+ and Graphviz (for documentation)
 - ClangFormat 22.1 or newer

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -28,7 +28,7 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
   # MSVC Compiler Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/compiler-options-listed-by-category?view=msvc-170#optimization
-  # last option is /forceInterlockedFunctions
+  # last option is /fp
 
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
@@ -36,14 +36,14 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
     set(CMAKE_C_FLAGS                  "/EHsc")
     set(CMAKE_CXX_FLAGS                "/EHsc")
 
-    set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy-")
-    set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy-")
+    set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")
+    set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")
 
-    set(CMAKE_C_FLAGS_RELWITHDEBINFO   "/Ox /Ob3 /Oi  /Ot /Oy-")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Ob3 /Oi  /Ot /Oy-")
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO   "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except")
 
-    set(CMAKE_C_FLAGS_RELEASE          "/Ox /Ob3 /Oi  /Ot /Oy")
-    set(CMAKE_CXX_FLAGS_RELEASE        "/Ox /Ob3 /Oi  /Ot /Oy")
+    set(CMAKE_C_FLAGS_RELEASE          "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except-")
+    set(CMAKE_CXX_FLAGS_RELEASE        "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except-")
 
 
     set(CMAKE_STATIC_LINKER_FLAGS                 "")

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -39,8 +39,8 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
     set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")
     set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")
 
-    set(CMAKE_C_FLAGS_RELWITHDEBINFO   "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except")
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO   "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except-")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except-")
 
     set(CMAKE_C_FLAGS_RELEASE          "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except-")
     set(CMAKE_CXX_FLAGS_RELEASE        "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except-")

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -18,7 +18,7 @@
 # DEALINGS IN THE SOFTWARE.
 #-----------------------------------------------------------------------------------------------------------------------
 
-find_package(Doxygen 1.17.0 REQUIRED COMPONENTS dot)
+find_package(Doxygen 1.18.0 REQUIRED COMPONENTS dot)
 
 get_target_property(DOXYGEN_DOT_LOCATION Doxygen::dot IMPORTED_LOCATION)
 get_filename_component(DOXYGEN_DOT_DIR "${DOXYGEN_DOT_LOCATION}" DIRECTORY)

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,4 +1,4 @@
-# Doxyfile 1.17.0
+# Doxyfile 1.18.0
 
 # This file describes the settings to be used by the documentation system
 # Doxygen (www.doxygen.org) for a project.
@@ -11,7 +11,7 @@
 # TAG = value [value, ...]
 # For lists, items can also be appended using:
 # TAG += value [value, ...]
-# Values that contain spaces should be placed between quotes (\" \").
+# Values that contain spaces should be placed between quotes (" ").
 #
 # Note:
 #
@@ -855,8 +855,8 @@ SHOW_NAMESPACES        = YES
 # The FILE_VERSION_FILTER tag can be used to specify a program or script that
 # Doxygen should invoke to get the current version for each file (typically from
 # the version control system). Doxygen will invoke the program by executing (via
-# popen()) the command command input-file, where command is the value of the
-# FILE_VERSION_FILTER tag, and input-file is the name of an input file provided
+# popen()) the command command input_file, where command is the value of the
+# FILE_VERSION_FILTER tag, and input_file is the name of an input file provided
 # by Doxygen. Whatever the program writes to standard output is used as the file
 # version. For an example see the documentation.
 
@@ -2208,9 +2208,8 @@ EXTRA_PACKAGES         =
 #
 # Note: Only use a user-defined header if you know what you are doing!
 # Note: The header is subject to change so you typically have to regenerate the
-# default header when upgrading to a newer version of Doxygen. The following
-# commands have a special meaning inside the header (and footer): For a
-# description of the possible markers and block names see the documentation.
+# default header when upgrading to a newer version of Doxygen. For a description
+# of the possible markers and block names see the documentation.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_HEADER           =
@@ -2951,7 +2950,7 @@ INTERACTIVE_SVG        = YES
 # found. If left blank, it is assumed the dot tool can be found in the path.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_PATH               = "@DOXYGEN_DOT_DIR@"
+DOT_PATH               = @DOXYGEN_DOT_DIR@
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that
 # contain dot files that are included in the documentation (see the \dotfile
@@ -3033,10 +3032,10 @@ MERMAID_RENDER_MODE    = CLI
 # relative path, or use MERMAID_RENDER_MODE=CLI to pre-generate images instead.
 # Examples:
 # - Latest v11 (default):
-# 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs'
+# https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs
 # - Pinned version:
-# 'https://cdn.jsdelivr.net/npm/mermaid@11.3.0/dist/mermaid.esm.min.mjs'
-# - Local copy: './mermaid.esm.min.mjs' (user must place file in HTML output
+# https://cdn.jsdelivr.net/npm/mermaid@11.3.0/dist/mermaid.esm.min.mjs
+# - Local copy: ./mermaid.esm.min.mjs (user must place file in HTML output
 # directory)
 # The default value is:
 # https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs.

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -2950,7 +2950,7 @@ INTERACTIVE_SVG        = YES
 # found. If left blank, it is assumed the dot tool can be found in the path.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_PATH               = @DOXYGEN_DOT_DIR@
+DOT_PATH               = "@DOXYGEN_DOT_DIR@"
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that
 # contain dot files that are included in the documentation (see the \dotfile


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating ZIP packages containing the static library, headers, and license information.
  * Package names can now be customized or generated automatically for the target platform.

* **Documentation**
  * Updated documentation requirements to Doxygen 1.18 or later, with Graphviz support.

* **Build Improvements**
  * Improved compiler floating-point settings across Debug, Release, and RelWithDebInfo builds.
  * Improved package-cache handling to speed up compatible builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->