### PR TITLE
build(cpack): pack the sample into a runtime group archive

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -384,3 +384,7 @@ jobs:
         with:
           path: ${{ runner.temp }}/apt-cache
           key: ${{ steps.sonar-cloud-apt-cache.outputs.cache-primary-key }}
+
+      - name: Prepare compile_commands.json
+        run: |
+          cmake --preset linux-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,9 +169,9 @@ endif ()
 # Packaging
 #-----------------------------------------------------------------------------------------------------------------------
 
-# Packs whatever the build installed: the library, its headers and the license. The 'runtime' component arrives with the
-# sample install rules. include(CPack) must stay last, after every install() rule, otherwise the component list it
-# captures is incomplete.
+# Packs what the build installed, one archive per component group. Group 'runtime' is everything a consumer needs: the
+# library, its headers, the license and the sample executables. include(CPack) must stay last, after every install()
+# rule, otherwise the component list it captures is incomplete.
 if (TOP_PROJECT)
   set(CPACK_GENERATOR "ZIP")
   set(CPACK_PACKAGE_NAME "${PROJECT_NAME}${PACKAGE_NAME_SUFFIX}")
@@ -181,11 +181,17 @@ if (TOP_PROJECT)
   set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ToyGine 2 static library, headers and samples")
   set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
   # Component install mode is what filters the archive down to CPACK_COMPONENTS_ALL: without it CPack packs every
-  # install() rule in the build, including those the FetchContent dependencies declare for themselves. Grouping puts
-  # the components back into a single archive instead of one per component.
-  set(CPACK_COMPONENTS_ALL headers library license)
+  # install() rule in the build, including those the FetchContent dependencies declare for themselves.
+  set(CPACK_COMPONENTS_ALL headers library license samples)
   set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
-  set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
+  set(CPACK_COMPONENTS_GROUPING ONE_PER_GROUP)
+
+  # One group today, so one archive. The symbols step adds a 'debug' group holding a 'symbols' component; the group is
+  # named 'debug' so it never collides with that component name.
+  set(CPACK_COMPONENT_HEADERS_GROUP runtime)
+  set(CPACK_COMPONENT_LIBRARY_GROUP runtime)
+  set(CPACK_COMPONENT_LICENSE_GROUP runtime)
+  set(CPACK_COMPONENT_SAMPLES_GROUP runtime)
 
   # Component mode reads this one instead of CPACK_INCLUDE_TOPLEVEL_DIRECTORY, and defaults it off: unpacking would
   # spill include/, lib/ and LICENSE into the current directory.
@@ -202,6 +208,10 @@ if (TOP_PROJECT)
   endif ()
 
   set(CPACK_PACKAGE_FILE_NAME "${_base_name}")
+
+  # In ONE_PER_GROUP mode the archive name comes from this per-group variable, not from CPACK_PACKAGE_FILE_NAME, which
+  # only names the directory inside every archive.
+  set(CPACK_ARCHIVE_RUNTIME_FILE_NAME "${_base_name}")
 
   include(CPack)
 endif ()

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -28,13 +28,13 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
   # MSVC Compiler Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/compiler-options-listed-by-category?view=msvc-170#optimization
-  # last option is /fp
+  # last option is /fpcvt
 
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
 
-    set(CMAKE_C_FLAGS                  "/EHsc")
-    set(CMAKE_CXX_FLAGS                "/EHsc")
+    set(CMAKE_C_FLAGS                  "/EHsc /fpcvt:IA")
+    set(CMAKE_CXX_FLAGS                "/EHsc /fpcvt:IA")
 
     set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")
     set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -33,8 +33,8 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
 
-    set(CMAKE_C_FLAGS                  "/EHsc /fpcvt:IA")
-    set(CMAKE_CXX_FLAGS                "/EHsc /fpcvt:IA")
+    set(CMAKE_C_FLAGS                  "/EHsc")
+    set(CMAKE_CXX_FLAGS                "/EHsc")
 
     set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")
     set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")
@@ -60,8 +60,8 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
     if (CMAKE_VS_PLATFORM_NAME STREQUAL "x64")
 
-      string(APPEND CMAKE_C_FLAGS   " /arch:SSE2")
-      string(APPEND CMAKE_CXX_FLAGS " /arch:SSE2")
+      string(APPEND CMAKE_C_FLAGS   " /arch:SSE2 /fpcvt:IA")
+      string(APPEND CMAKE_CXX_FLAGS " /arch:SSE2 /fpcvt:IA")
 
       string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          " /dynamicdeopt:sync /favor:blend")
       string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        " /dynamicdeopt:sync /favor:blend")
@@ -73,8 +73,8 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
     elseif (CMAKE_VS_PLATFORM_NAME STREQUAL "Win32")
 
-      string(APPEND CMAKE_C_FLAGS   " /arch:SSE2")
-      string(APPEND CMAKE_CXX_FLAGS " /arch:SSE2")
+      string(APPEND CMAKE_C_FLAGS   " /arch:SSE2 /fpcvt:IA")
+      string(APPEND CMAKE_CXX_FLAGS " /arch:SSE2 /fpcvt:IA")
 
       string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          "                    /favor:blend")
       string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        "                    /favor:blend")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Windows build compatibility for supported compiler configurations.
  * Updated packaging to include sample files alongside headers, libraries, and licensing information in the runtime archive.
* **Build & Packaging**
  * Enhanced code analysis setup by generating compilation metadata during debug builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->