### PR TITLE
ci: add SonarQube scanning to CMake workflow

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -336,6 +336,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.1
         with:
+          fetch-depth: 0
           submodules: recursive
           persist-credentials: false
 

--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -19,21 +19,18 @@ jobs:
           - name: Windows MSVC x64
             os: windows-2025-vs2026
             run_benchmarks: "true"
-            bencher_testbed: windows-x64
             run_test: "true"
             cmake_preset: windows-msvc-x64
 
           - name: Windows MSVC x86
             os: windows-2025-vs2026
             run_benchmarks: "true"
-            bencher_testbed: windows-x86
             run_test: "true"
             cmake_preset: windows-msvc-x86
 
           - name: Windows MSVC Arm64
             os: windows-11-vs2026-arm
             run_benchmarks: "true"
-            bencher_testbed: windows-arm64
             run_test: "true"
             cmake_preset: windows-msvc-arm64
 
@@ -50,28 +47,24 @@ jobs:
           - name: macOS Ninja arm64
             os: macos-26
             run_benchmarks: "true"
-            bencher_testbed: macos-arm64
             run_test: "true"
             cmake_preset: macos-release
 
           - name: macOS Ninja Intel
             os: macos-26-intel
             run_benchmarks: "true"
-            bencher_testbed: macos-x64
             run_test: "true"
             cmake_preset: macos-release
 
           - name: Linux Ninja x64
             os: ubuntu-26.04
             run_benchmarks: "true"
-            bencher_testbed: ubuntu-x64
             run_test: "true"
             cmake_preset: linux-release
 
           - name: Linux Ninja arm64
             os: ubuntu-26.04-arm
             run_benchmarks: "true"
-            bencher_testbed: ubuntu-arm64
             run_test: "true"
             cmake_preset: linux-release
 
@@ -209,6 +202,15 @@ jobs:
         uses: TheMrMilchmann/setup-msvc-dev@v4.1.0
         with:
           arch: ${{ contains(matrix.cmake_preset, 'arm64') && 'arm64' || contains(matrix.cmake_preset, 'x86') && 'x86' || 'x64' }}
+
+      - name: Prepare artifact name
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ARTIFACT_ID: ${{ matrix.cmake_preset }}
+        run: |
+          set -euo pipefail
+          echo "BUILD_FILE_NAME=${ARTIFACT_ID}-${HEAD_SHA:0:7}" >> "$GITHUB_ENV"
 
       - name: Build
         run: |
@@ -389,7 +391,7 @@ jobs:
         run: |
           cmake --preset linux-debug
 
-      - uses: SonarSource/sonarqube-scan-action@v8.2.0
+      - uses: SonarSource/sonarqube-scan-action@v8.2.1
         with:
           args: >-
             -Dsonar.cfamily.compile-commands=out/build/linux-debug/compile_commands.json

--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -388,3 +388,14 @@ jobs:
       - name: Prepare compile_commands.json
         run: |
           cmake --preset linux-debug
+
+      - uses: SonarSource/sonarqube-scan-action@v8.2.0
+        with:
+          args: >-
+            -Dsonar.cfamily.compile-commands=out/build/linux-debug/compile_commands.json
+            -Dsonar.cfamily.analysisCache.mode=fs
+            -Dsonar.cfamily.analysisCache.path=.sonar-cfamily-cache
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -33,8 +33,8 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
 
-    set(CMAKE_C_FLAGS                  "/EHsc")
-    set(CMAKE_CXX_FLAGS                "/EHsc")
+    set(CMAKE_C_FLAGS                  "/EHsc /GA")
+    set(CMAKE_CXX_FLAGS                "/EHsc /GA")
 
     set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")
     set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
    - Added `SonarSource/sonarqube-scan-action@v8.2.1` step to `.github/workflows/build_cmake.yaml` for CFamily analysis.
    - Removed `bencher_testbed` properties and added dynamic artifact name preparation for pull requests in `.github/workflows/build_cmake.yaml`.
- **Build configuration:**
    - Added `/GA` compiler flag to `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` for Windows Desktop targets in `cmake/ConfigureCompiler.cmake`.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved build validation across supported Windows, macOS, and Linux configurations.
  * Build artifacts generated for pull requests now use clearer, uniquely identifiable names.
  * Enhanced static analysis coverage and reliability for detecting code quality issues.

* **Performance**
  * Updated compiler settings for improved application data access behavior on supported MSVC builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->