### PR TITLE
ci: publish desktop build artifacts on pull requests

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -21,52 +21,61 @@ jobs:
             run_benchmarks: "true"
             run_test: "true"
             cmake_preset: windows-msvc-x64
+            artifact_id: windows-x64
 
           - name: Windows MSVC x86
             os: windows-2025-vs2026
             run_benchmarks: "true"
             run_test: "true"
             cmake_preset: windows-msvc-x86
+            artifact_id: windows-x86
 
           - name: Windows MSVC Arm64
             os: windows-11-vs2026-arm
             run_benchmarks: "true"
             run_test: "true"
             cmake_preset: windows-msvc-arm64
+            artifact_id: windows-arm64
 
           - name: macOS XCode arm64
             os: macos-26
             run_test: "true"
             cmake_preset: macos-xcode
+            artifact_id: macos-xcode-arm64
 
           - name: macOS XCode Intel
             os: macos-26-intel
             run_test: "true"
             cmake_preset: macos-xcode
+            artifact_id: macos-xcode-x64
 
           - name: macOS Ninja arm64
             os: macos-26
             run_benchmarks: "true"
             run_test: "true"
             cmake_preset: macos-release
+            artifact_id: macos-ninja-arm64
 
           - name: macOS Ninja Intel
             os: macos-26-intel
             run_benchmarks: "true"
             run_test: "true"
             cmake_preset: macos-release
+            artifact_id: macos-ninja-x64
 
           - name: Linux Ninja x64
             os: ubuntu-26.04
             run_benchmarks: "true"
             run_test: "true"
             cmake_preset: linux-release
+            artifact_id: linux-x64
 
           - name: Linux Ninja arm64
             os: ubuntu-26.04-arm
             run_benchmarks: "true"
             run_test: "true"
             cmake_preset: linux-release
+            artifact_id: linux-arm64
 
           - name: Sega Mega Drive
             os: ubuntu-26.04
@@ -204,10 +213,10 @@ jobs:
           arch: ${{ contains(matrix.cmake_preset, 'arm64') && 'arm64' || contains(matrix.cmake_preset, 'x86') && 'x86' || 'x64' }}
 
       - name: Prepare artifact name
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ matrix.artifact_id != '' && github.event_name == 'pull_request' }}
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          ARTIFACT_ID: ${{ matrix.cmake_preset }}
+          ARTIFACT_ID: ${{ matrix.artifact_id }}
         run: |
           set -euo pipefail
           echo "BUILD_FILE_NAME=${ARTIFACT_ID}-${HEAD_SHA:0:7}" >> "$GITHUB_ENV"
@@ -220,6 +229,21 @@ jobs:
           fi
           cmake $BENCHMARKS_ARG --preset ${{ matrix.cmake_preset }}
           cmake --build --preset ${{ matrix.cmake_preset }}
+
+      - name: Package
+        if: ${{ matrix.artifact_id != '' && github.event_name == 'pull_request' }}
+        run: |
+          set -euo pipefail
+          cpack --preset ${{ matrix.cmake_preset }}
+
+      - name: Upload runtime artifact
+        if: ${{ matrix.artifact_id != '' && github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: ${{ matrix.artifact_id }}
+          path: ${{ github.workspace }}/out/package/${{ matrix.cmake_preset }}/*.zip
+          retention-days: 7
+          if-no-files-found: error
 
       - name: Unit testing
         run: |

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -28,7 +28,7 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
   # MSVC Compiler Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/compiler-options-listed-by-category?view=msvc-170#optimization
-  # last option is /fpcvt
+  # last option is /Gd
 
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
@@ -36,14 +36,14 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
     set(CMAKE_C_FLAGS                  "/EHsc /GA")
     set(CMAKE_CXX_FLAGS                "/EHsc /GA")
 
-    set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")
-    set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except")
+    set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except  /Gd")
+    set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except  /Gd")
 
-    set(CMAKE_C_FLAGS_RELWITHDEBINFO   "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except-")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except-")
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO   "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except- /Gr")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except- /Gr")
 
-    set(CMAKE_C_FLAGS_RELEASE          "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except-")
-    set(CMAKE_CXX_FLAGS_RELEASE        "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except-")
+    set(CMAKE_C_FLAGS_RELEASE          "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except- /Gr")
+    set(CMAKE_CXX_FLAGS_RELEASE        "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except- /Gr")
 
 
     set(CMAKE_STATIC_LINKER_FLAGS                 "")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Builds and Packaging**
  * Added platform-specific names for native build artifacts.
  * Pull requests now generate and upload runtime ZIP packages.
  * Packaged artifacts are retained for seven days, with clear errors when files are missing.

* **Windows Compatibility**
  * Updated compiler settings for Windows desktop builds across Debug, RelWithDebInfo, and Release configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->