### PR TITLE
feat(gba): add console sample ROM build and CI artifact

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -88,6 +88,7 @@ jobs:
             container: ghcr.io/toymaninteractive/toygine2.gba.toolchain:latest
             run_test: "false"
             cmake_preset: gba-release
+            artifact_id: gba
 
           - name: Nintendo DS
             os: ubuntu-26.04

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1050,6 +1050,22 @@
                 "type-shipping",
                 "base"
             ]
+        },
+        {
+            "name": "gba-release",
+            "configurePreset": "gba-release",
+            "inherits": [
+                "type-release",
+                "base"
+            ]
+        },
+        {
+            "name": "gba-shipping",
+            "configurePreset": "gba-shipping",
+            "inherits": [
+                "type-shipping",
+                "base"
+            ]
         }
     ]
 }

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -28,13 +28,13 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
   # MSVC Compiler Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/compiler-options-listed-by-category?view=msvc-170#optimization
-  # last option is /GL
+  # last option is /GR
 
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
 
-    set(CMAKE_C_FLAGS                  "/EHsc /GA")
-    set(CMAKE_CXX_FLAGS                "/EHsc /GA")
+    set(CMAKE_C_FLAGS                  "/EHsc /GA /GR-")
+    set(CMAKE_CXX_FLAGS                "/EHsc /GA /GR-")
 
     set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except  /Gd /GF- /GL-")
     set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except  /Gd /GF- /GL-")

--- a/samples/console/CMakeLists.txt
+++ b/samples/console/CMakeLists.txt
@@ -22,4 +22,12 @@ add_executable(console_sample_app console_sample_app.cpp)
 
 target_link_libraries(console_sample_app PRIVATE toygine)
 
-install(TARGETS console_sample_app RUNTIME DESTINATION bin COMPONENT samples)
+if (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo GBA")
+
+  gba_create_rom(console_sample_app)
+
+else ()
+
+  install(TARGETS console_sample_app RUNTIME DESTINATION bin COMPONENT samples)
+
+endif ()

--- a/samples/console/CMakeLists.txt
+++ b/samples/console/CMakeLists.txt
@@ -26,6 +26,8 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo GBA")
 
   gba_create_rom(console_sample_app)
 
+  install(FILES console_sample_app.gba DESTINATION bin COMPONENT samples)
+
 else ()
 
   install(TARGETS console_sample_app RUNTIME DESTINATION bin COMPONENT samples)

--- a/samples/console/CMakeLists.txt
+++ b/samples/console/CMakeLists.txt
@@ -26,7 +26,7 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo GBA")
 
   gba_create_rom(console_sample_app)
 
-  install(FILES console_sample_app.gba DESTINATION bin COMPONENT samples)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/console_sample_app.gba" DESTINATION bin COMPONENT samples)
 
 else ()
 

--- a/samples/console/console_sample_app.cpp
+++ b/samples/console/console_sample_app.cpp
@@ -22,6 +22,30 @@
   \brief
 */
 
+#ifdef __GBA__
+
+#include <gba_console.h>
+#include <gba_interrupt.h>
+#include <gba_systemcalls.h>
+
+int main() {
+  irqInit();
+  irqEnable(IRQ_VBLANK);
+
+  consoleDemoInit();
+
+  iprintf("\x1b[0;7HHello world from Console sample app");
+
+  while (1)
+    VBlankIntrWait();
+
+  return 0;
+}
+
+#endif // __GBA__
+
+#if !defined(__GBA__)
+
 #include <iostream>
 
 #include "toygine.hpp"
@@ -31,3 +55,5 @@ int main(int argc, char * argv[]) noexcept {
 
   return EXIT_SUCCESS;
 }
+
+#endif // __GBA__

--- a/samples/console/console_sample_app.cpp
+++ b/samples/console/console_sample_app.cpp
@@ -24,6 +24,8 @@
 
 #ifdef __GBA__
 
+#include <cstdio>
+
 #include <gba_console.h>
 #include <gba_interrupt.h>
 #include <gba_systemcalls.h>

--- a/samples/console/console_sample_app.cpp
+++ b/samples/console/console_sample_app.cpp
@@ -34,7 +34,7 @@ int main() {
 
   consoleDemoInit();
 
-  iprintf("\x1b[0;7HHello world from Console sample app");
+  printf("Hello world from Console sample app");
 
   while (1)
     VBlankIntrWait();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release and shipping package presets for Nintendo GBA builds.
  * GBA builds now produce a packaged `.gba` ROM artifact with consistent naming.
  * Updated the console sample to run natively on GBA, displaying a message and waiting for screen refreshes.
  * Preserved the existing executable-based console sample workflow on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->