### PR TITLE
feat(samples): add Nintendo Switch console example

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -109,6 +109,7 @@ jobs:
             container: ghcr.io/toymaninteractive/toygine2.switch.toolchain:latest
             run_test: "false"
             cmake_preset: switch-release
+            artifact_id: switch
 
           - name: Nintendo GameCube
             os: ubuntu-26.04

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1098,6 +1098,22 @@
                 "type-shipping",
                 "base"
             ]
+        },
+        {
+            "name": "switch-release",
+            "configurePreset": "switch-release",
+            "inherits": [
+                "type-release",
+                "base"
+            ]
+        },
+        {
+            "name": "switch-shipping",
+            "configurePreset": "switch-shipping",
+            "inherits": [
+                "type-shipping",
+                "base"
+            ]
         }
     ]
 }

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -28,7 +28,7 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
   # MSVC Compiler Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/compiler-options-listed-by-category?view=msvc-170#optimization
-  # last option is /guard
+  # last option is /Gv
 
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
@@ -39,11 +39,11 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
     set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except  /Gd /GF- /GL-")
     set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except  /Gd /GF- /GL-")
 
-    set(CMAKE_C_FLAGS_RELWITHDEBINFO   "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except- /Gr /GF  /GL")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except- /Gr /GF  /GL")
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO   "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except-     /GF  /GL")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except-     /GF  /GL")
 
-    set(CMAKE_C_FLAGS_RELEASE          "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except- /Gr /GF  /GL")
-    set(CMAKE_CXX_FLAGS_RELEASE        "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except- /Gr /GF  /GL")
+    set(CMAKE_C_FLAGS_RELEASE          "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except-     /GF  /GL")
+    set(CMAKE_CXX_FLAGS_RELEASE        "/Ox /Ob3 /Oi  /Ot /Oy  /fp:fast   /fp:except-     /GF  /GL")
 
 
     set(CMAKE_STATIC_LINKER_FLAGS                 "")
@@ -63,11 +63,11 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
       string(APPEND CMAKE_C_FLAGS   " /arch:SSE2 /fpcvt:IA")
       string(APPEND CMAKE_CXX_FLAGS " /arch:SSE2 /fpcvt:IA")
 
-      string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          " /favor:blend")
-      string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        " /favor:blend")
+      string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          " /favor:blend /Gv")
+      string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        " /favor:blend /Gv")
 
-      string(APPEND CMAKE_C_FLAGS_RELEASE                 " /favor:blend")
-      string(APPEND CMAKE_CXX_FLAGS_RELEASE               " /favor:blend")
+      string(APPEND CMAKE_C_FLAGS_RELEASE                 " /favor:blend /Gv")
+      string(APPEND CMAKE_CXX_FLAGS_RELEASE               " /favor:blend /Gv")
 
       string(APPEND CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "")
 
@@ -76,11 +76,11 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
       string(APPEND CMAKE_C_FLAGS   " /arch:SSE2 /fpcvt:IA")
       string(APPEND CMAKE_CXX_FLAGS " /arch:SSE2 /fpcvt:IA")
 
-      string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          "                    /favor:blend")
-      string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        "                    /favor:blend")
+      string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          " /favor:blend /Gr")
+      string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        " /favor:blend /Gr")
 
-      string(APPEND CMAKE_C_FLAGS_RELEASE                 "                    /favor:blend")
-      string(APPEND CMAKE_CXX_FLAGS_RELEASE               "                    /favor:blend")
+      string(APPEND CMAKE_C_FLAGS_RELEASE                 " /favor:blend /Gr")
+      string(APPEND CMAKE_CXX_FLAGS_RELEASE               " /favor:blend /Gr")
 
     elseif (CMAKE_VS_PLATFORM_NAME STREQUAL "ARM64")
 

--- a/samples/console/CMakeLists.txt
+++ b/samples/console/CMakeLists.txt
@@ -40,6 +40,12 @@ elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo 3DS")
 
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/console_sample_app.3dsx" DESTINATION bin COMPONENT samples)
 
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo Switch")
+
+  nx_create_nro(console_sample_app)
+
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/console_sample_app.nro" DESTINATION bin COMPONENT samples)
+
 else ()
 
   install(TARGETS console_sample_app RUNTIME DESTINATION bin COMPONENT samples)

--- a/samples/console/console_sample_app.cpp
+++ b/samples/console/console_sample_app.cpp
@@ -94,7 +94,40 @@ int main() {
 
 #endif // __3DS__
 
-#if !defined(__GBA__) && !defined(__NDS__) && !defined(__3DS__)
+#ifdef __SWITCH__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <switch.h>
+
+int main() {
+  consoleInit(NULL);
+
+  padConfigureInput(1, HidNpadStyleSet_NpadStandard);
+
+  PadState pad;
+  padInitializeDefault(&pad);
+
+  printf("Hello world from Console sample app");
+
+  while (appletMainLoop()) {
+    padUpdate(&pad);
+
+    u64 kDown = padGetButtonsDown(&pad);
+    if (kDown & HidNpadButton_Plus)
+      break;
+
+    consoleUpdate(NULL);
+  }
+
+  consoleExit(NULL);
+  return 0;
+}
+
+#endif // __SWITCH__
+
+#if !defined(__GBA__) && !defined(__NDS__) && !defined(__3DS__) && !defined(__SWITCH__)
 
 #include <iostream>
 

--- a/tests/runner/context.test.cpp
+++ b/tests/runner/context.test.cpp
@@ -23,10 +23,16 @@
 */
 
 #include <cstddef>
+#include <type_traits>
 
 #include <doctest/doctest.h>
 
 #include "toy_test.hpp"
+
+static_assert(!std::is_copy_constructible_v<toy::test::Context>, "Context must not be copy constructible");
+static_assert(!std::is_copy_assignable_v<toy::test::Context>, "Context must not be copy assignable");
+static_assert(!std::is_move_constructible_v<toy::test::Context>, "Context must not be move constructible");
+static_assert(!std::is_move_assignable_v<toy::test::Context>, "Context must not be move assignable");
 
 namespace {
 
@@ -100,7 +106,12 @@ TEST_CASE("test/context/failure_reaches_reporter") {
 
   context.record(false, "str.size() == 4", "tests/core/fixed_string.test.cpp", 88);
 
+  // Without a call the captured pointers stay null, which makes every comparison below meaningless.
   REQUIRE(g_captured.callCount == 1);
+  REQUIRE(g_captured.caseName != nullptr);
+  REQUIRE(g_captured.expression != nullptr);
+  REQUIRE(g_captured.file != nullptr);
+
   REQUIRE(toy::test::detail::compareNames(g_captured.caseName, "core/fixed_string/append") == 0);
   REQUIRE(toy::test::detail::compareNames(g_captured.expression, "str.size() == 4") == 0);
   REQUIRE(toy::test::detail::compareNames(g_captured.file, "tests/core/fixed_string.test.cpp") == 0);
@@ -117,6 +128,8 @@ TEST_CASE("test/context/info_reaches_reporter") {
   context.record(false, "value == 0", "file.cpp", 7);
 
   REQUIRE(g_captured.infoCount == 1);
+  REQUIRE(g_captured.firstInfo != nullptr);
+
   REQUIRE(toy::test::detail::compareNames(g_captured.firstInfo, "index") == 0);
   REQUIRE(g_captured.firstValue == 3);
 }
@@ -141,7 +154,9 @@ TEST_CASE("test/context/info_without_value") {
   context.beginCase("some/case");
   context.pushInfo("after reload");
 
+  // infoAt() requires an index below infoCount(), so the count gates the read.
   REQUIRE(context.infoCount() == 1);
+
   REQUIRE(context.infoAt(0).hasValue == false);
 }
 
@@ -151,12 +166,12 @@ TEST_CASE("test/context/info_stack_overflow_stays_balanced") {
   toy::test::Context context{&captureFailure};
   context.beginCase("some/case");
 
-  for (std::size_t index = 0; index < 12; ++index)
+  for (std::size_t index = 0; index < toy::test::Context::c_maxInfoDepth + 4; ++index)
     context.pushInfo("entry", static_cast<long long>(index));
 
-  REQUIRE(context.infoCount() == 8);
+  REQUIRE(context.infoCount() == toy::test::Context::c_maxInfoDepth);
 
-  for (std::size_t index = 0; index < 12; ++index)
+  for (std::size_t index = 0; index < toy::test::Context::c_maxInfoDepth + 4; ++index)
     context.popInfo();
 
   REQUIRE(context.infoCount() == 0);
@@ -173,6 +188,9 @@ TEST_CASE("test/context/begin_case_clears_verdict_and_keeps_totals") {
 
   REQUIRE(context.caseFailed() == false);
   REQUIRE(context.failedCount() == 1);
-  REQUIRE(toy::test::detail::compareNames(context.caseName(), "second/case") == 0);
   REQUIRE(context.subcaseName() == nullptr);
+
+  REQUIRE(context.caseName() != nullptr);
+
+  REQUIRE(toy::test::detail::compareNames(context.caseName(), "second/case") == 0);
 }

--- a/tests/runner/context.test.cpp
+++ b/tests/runner/context.test.cpp
@@ -1,0 +1,178 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   context.test.cpp
+  \brief  Unit tests for \ref toy::test::Context: assertion counters, failure reporting and the info stack.
+*/
+
+#include <cstddef>
+
+#include <doctest/doctest.h>
+
+#include "toy_test.hpp"
+
+namespace {
+
+struct CapturedFailure final {
+  const char * caseName   = nullptr;
+  const char * expression = nullptr;
+  const char * file       = nullptr;
+  int          line       = 0;
+  std::size_t  infoCount  = 0;
+  const char * firstInfo  = nullptr;
+  long long    firstValue = 0;
+  std::size_t  callCount  = 0;
+};
+
+CapturedFailure g_captured;
+
+void captureFailure(const toy::test::Context & context, const toy::test::FailureRecord & failure) noexcept {
+  g_captured.caseName   = failure.caseName;
+  g_captured.expression = failure.expression;
+  g_captured.file       = failure.file;
+  g_captured.line       = failure.line;
+  g_captured.infoCount  = context.infoCount();
+  g_captured.firstInfo  = context.infoCount() > 0 ? context.infoAt(0).text : nullptr;
+  g_captured.firstValue = context.infoCount() > 0 ? context.infoAt(0).value : 0;
+  ++g_captured.callCount;
+}
+
+// Fresh capture plus a context wired to it; every case starts from this to stay order-independent.
+CapturedFailure & resetCapture() {
+  g_captured = CapturedFailure{};
+
+  return g_captured;
+}
+
+} // namespace
+
+// A passing assertion counts as passed, returns true and leaves the case clean.
+TEST_CASE("test/context/record_passing_assertion") {
+  resetCapture();
+  toy::test::Context context{&captureFailure};
+  context.beginCase("some/case");
+
+  const bool result = context.record(true, "1 == 1", "file.cpp", 10);
+
+  REQUIRE(result == true);
+  REQUIRE(context.passedCount() == 1);
+  REQUIRE(context.failedCount() == 0);
+  REQUIRE(context.caseFailed() == false);
+  REQUIRE(g_captured.callCount == 0);
+}
+
+// A failing assertion counts as failed, returns false and marks the case.
+TEST_CASE("test/context/record_failing_assertion") {
+  resetCapture();
+  toy::test::Context context{&captureFailure};
+  context.beginCase("some/case");
+
+  const bool result = context.record(false, "1 == 2", "file.cpp", 42);
+
+  REQUIRE(result == false);
+  REQUIRE(context.passedCount() == 0);
+  REQUIRE(context.failedCount() == 1);
+  REQUIRE(context.caseFailed() == true);
+}
+
+// The reporter receives the case name and the assertion's own source location.
+TEST_CASE("test/context/failure_reaches_reporter") {
+  resetCapture();
+  toy::test::Context context{&captureFailure};
+  context.beginCase("core/fixed_string/append");
+
+  context.record(false, "str.size() == 4", "tests/core/fixed_string.test.cpp", 88);
+
+  REQUIRE(g_captured.callCount == 1);
+  REQUIRE(toy::test::detail::compareNames(g_captured.caseName, "core/fixed_string/append") == 0);
+  REQUIRE(toy::test::detail::compareNames(g_captured.expression, "str.size() == 4") == 0);
+  REQUIRE(toy::test::detail::compareNames(g_captured.file, "tests/core/fixed_string.test.cpp") == 0);
+  REQUIRE(g_captured.line == 88);
+}
+
+// Info entries pushed before a failure reach the reporter through the context.
+TEST_CASE("test/context/info_reaches_reporter") {
+  resetCapture();
+  toy::test::Context context{&captureFailure};
+  context.beginCase("some/case");
+  context.pushInfo("index", 3);
+
+  context.record(false, "value == 0", "file.cpp", 7);
+
+  REQUIRE(g_captured.infoCount == 1);
+  REQUIRE(toy::test::detail::compareNames(g_captured.firstInfo, "index") == 0);
+  REQUIRE(g_captured.firstValue == 3);
+}
+
+// Popping removes the entry, so a later failure carries no stale context.
+TEST_CASE("test/context/pop_info_removes_entry") {
+  resetCapture();
+  toy::test::Context context{&captureFailure};
+  context.beginCase("some/case");
+  context.pushInfo("index", 3);
+  context.popInfo();
+
+  context.record(false, "value == 0", "file.cpp", 7);
+
+  REQUIRE(g_captured.infoCount == 0);
+}
+
+// A message without a value reports hasValue false, so the reporter can omit the number.
+TEST_CASE("test/context/info_without_value") {
+  resetCapture();
+  toy::test::Context context{&captureFailure};
+  context.beginCase("some/case");
+  context.pushInfo("after reload");
+
+  REQUIRE(context.infoCount() == 1);
+  REQUIRE(context.infoAt(0).hasValue == false);
+}
+
+// Pushing past the fixed depth drops the surplus but keeps push and pop balanced.
+TEST_CASE("test/context/info_stack_overflow_stays_balanced") {
+  resetCapture();
+  toy::test::Context context{&captureFailure};
+  context.beginCase("some/case");
+
+  for (std::size_t index = 0; index < 12; ++index)
+    context.pushInfo("entry", static_cast<long long>(index));
+
+  REQUIRE(context.infoCount() == 8);
+
+  for (std::size_t index = 0; index < 12; ++index)
+    context.popInfo();
+
+  REQUIRE(context.infoCount() == 0);
+}
+
+// beginCase clears the per-case verdict but keeps the totals, which span the whole run.
+TEST_CASE("test/context/begin_case_clears_verdict_and_keeps_totals") {
+  resetCapture();
+  toy::test::Context context{&captureFailure};
+  context.beginCase("first/case");
+  context.record(false, "1 == 2", "file.cpp", 1);
+
+  context.beginCase("second/case");
+
+  REQUIRE(context.caseFailed() == false);
+  REQUIRE(context.failedCount() == 1);
+  REQUIRE(toy::test::detail::compareNames(context.caseName(), "second/case") == 0);
+  REQUIRE(context.subcaseName() == nullptr);
+}

--- a/tests/runner/toy_test.hpp
+++ b/tests/runner/toy_test.hpp
@@ -321,6 +321,9 @@ using failure_reporter_type = void (*)(const Context & context, const FailureRec
 */
 class Context final {
 public:
+  /// Depth of the info stack; messages beyond it are dropped.
+  static constexpr std::size_t c_maxInfoDepth = 8;
+
   /*!
     \brief Builds a context reporting failures through \a reporter.
 
@@ -355,7 +358,7 @@ public:
 
     \return \a passed, so a caller can return early on failure.
 
-    \post On failure the case is marked and the reporter has been invoked exactly once.
+    \post On failure the case is marked. If the reporter is non-null, it is invoked exactly once.
 
     \sa caseFailed()
   */
@@ -414,14 +417,14 @@ public:
   [[nodiscard]] const char * subcaseName() const noexcept;
 
 private:
-  failure_reporter_type    _reporter;
-  const char *             _caseName;
-  const char *             _subcaseName;
-  std::size_t              _passedCount;
-  std::size_t              _failedCount;
-  std::size_t              _infoDepth;
-  bool                     _caseFailed;
-  std::array<InfoEntry, 8> _infoStack;
+  failure_reporter_type                 _reporter;
+  const char *                          _caseName;
+  const char *                          _subcaseName;
+  std::size_t                           _passedCount;
+  std::size_t                           _failedCount;
+  std::size_t                           _infoDepth;
+  bool                                  _caseFailed;
+  std::array<InfoEntry, c_maxInfoDepth> _infoStack;
 };
 
 } // namespace toy::test

--- a/tests/runner/toy_test.hpp
+++ b/tests/runner/toy_test.hpp
@@ -208,6 +208,222 @@ template <std::floating_point T>
 
 } // namespace detail
 
+/*!
+  \struct FailureRecord
+  \brief One failed assertion, as handed to a failure reporter.
+
+  Carries only what the reporter cannot recover on its own. The info stack travels separately, through the
+  \ref toy::test::Context passed alongside.
+
+  \section usage Usage Example
+
+  \code
+  void report(const toy::test::Context & context, const toy::test::FailureRecord & failure) noexcept;
+  \endcode
+
+  \section performance Performance Characteristics
+
+  * **Construction**: O(1) constant time
+  * **Access**: O(1) constant time
+  * **Memory usage**: 4 pointers plus one int
+
+  \section safety Safety Guarantees
+
+  * **Type safety**: aggregate of pointers to string literals and one line number
+  * **Memory safety**: no ownership; every pointer refers to a string literal that outlives the run
+  * **Exception safety**: No operation throws; exceptions are off in the build
+
+  \sa \ref toy::test::Context
+*/
+struct FailureRecord final {
+  const char * caseName;    ///< Name of the running case.
+  const char * subcaseName; ///< Name of the running subcase, or \c nullptr outside one.
+  const char * expression;  ///< Source text of the failed expression.
+  const char * file;        ///< Source file holding the assertion.
+  int          line;        ///< Source line holding the assertion.
+};
+
+/*!
+  \struct InfoEntry
+  \brief One message on the context's info stack.
+
+  \section usage Usage Example
+
+  \code
+  const toy::test::InfoEntry & entry = context.infoAt(0);
+  \endcode
+
+  \section performance Performance Characteristics
+
+  * **Construction**: O(1) constant time
+  * **Access**: O(1) constant time
+  * **Memory usage**: one pointer, one 64-bit integer and one flag
+
+  \section safety Safety Guarantees
+
+  * **Type safety**: \ref hasValue states whether \ref value carries meaning
+  * **Memory safety**: no ownership; \ref text refers to a string literal
+  * **Exception safety**: No operation throws; exceptions are off in the build
+
+  \sa \ref toy::test::Context
+*/
+struct InfoEntry final {
+  const char * text;     ///< Message text.
+  long long    value;    ///< Companion value, meaningful when \ref hasValue is \c true.
+  bool         hasValue; ///< Whether \ref value carries a number.
+};
+
+class Context;
+
+/// Function invoked for every failed assertion; see \ref toy::test::Context.
+using failure_reporter_type = void (*)(const Context & context, const FailureRecord & failure) noexcept;
+
+/*!
+  \class Context
+  \brief Per-run state of the built-in test runner.
+
+  Counts assertions, tracks the verdict of the running case and forwards every failure to the reporter given at
+  construction. Printing lives in the reporter, so the context stays testable without any output.
+
+  \section features Key Features
+
+  * **Allocation-free**: fixed-size info stack, no container and no heap
+  * **Explicit context**: no global state, so two runners can coexist in one process
+  * **Reporter seam**: failures leave through a function pointer, not a virtual call
+  * **Per-case verdict**: totals span the run while caseFailed() covers the running case
+
+  \section usage Usage Example
+
+  \code
+  #include "toy_test.hpp"
+
+  toy::test::Context context{&reportFailure};
+  context.beginCase("core/fixed_string/append");
+  context.record(str.size() == 4, "str.size() == 4", __FILE__, __LINE__);
+  \endcode
+
+  \section performance Performance Characteristics
+
+  * **Construction**: O(1) constant time
+  * **record()**: O(1) constant time
+  * **Memory usage**: 8 info entries plus counters, about 200 bytes
+
+  \section safety Safety Guarantees
+
+  * **Contracts**: infoAt() requires an index below infoCount()
+  * **Bounds safety**: pushInfo() past the depth drops the surplus and keeps push and pop balanced
+  * **Memory safety**: no dynamic allocation
+  * **Exception safety**: No operation throws; exceptions are off in the build
+
+  \note Every stored pointer refers to a string literal, so the context owns nothing.
+
+  \sa \ref toy::test::FailureRecord
+*/
+class Context final {
+public:
+  /*!
+    \brief Builds a context reporting failures through \a reporter.
+
+    \param reporter  Function invoked for every failed assertion; \c nullptr silences reporting.
+
+    \post Counters are zero and no case is running.
+  */
+  explicit Context(failure_reporter_type reporter) noexcept;
+
+  ~Context() noexcept                  = default;
+  Context(const Context &)             = delete;
+  Context & operator=(const Context &) = delete;
+  Context(Context &&)                  = delete;
+  Context & operator=(Context &&)      = delete;
+
+  /*!
+    \brief Starts a case and clears the per-case verdict.
+
+    \param name  Case name; must outlive the run.
+
+    \post caseFailed() is \c false, caseName() returns \a name, totals are unchanged.
+  */
+  void beginCase(const char * name) noexcept;
+
+  /*!
+    \brief Records one assertion result.
+
+    \param passed      Outcome of the asserted expression.
+    \param expression  Source text of the expression.
+    \param file        Source file holding the assertion.
+    \param line        Source line holding the assertion.
+
+    \return \a passed, so a caller can return early on failure.
+
+    \post On failure the case is marked and the reporter has been invoked exactly once.
+
+    \sa caseFailed()
+  */
+  bool record(bool passed, const char * expression, const char * file, int line) noexcept;
+
+  /*!
+    \brief Pushes a message onto the info stack.
+
+    \param text  Message text; must outlive the entry.
+
+    \post infoCount() grows by one unless the depth is already reached.
+
+    \sa popInfo()
+  */
+  void pushInfo(const char * text) noexcept;
+
+  /// Pushes a message carrying a number; see pushInfo().
+  void pushInfo(const char * text, long long value) noexcept;
+
+  /*!
+    \brief Pops the most recent message.
+
+    \post infoCount() shrinks by one unless the stack is empty.
+
+    \sa pushInfo()
+  */
+  void popInfo() noexcept;
+
+  /// Returns the number of assertions that passed during the run.
+  [[nodiscard]] std::size_t passedCount() const noexcept;
+
+  /// Returns the number of assertions that failed during the run.
+  [[nodiscard]] std::size_t failedCount() const noexcept;
+
+  /// Returns whether the running case has already failed an assertion.
+  [[nodiscard]] bool caseFailed() const noexcept;
+
+  /// Returns the number of messages currently on the info stack.
+  [[nodiscard]] std::size_t infoCount() const noexcept;
+
+  /*!
+    \brief Returns the message at \a index.
+
+    \param index  Position on the stack, oldest first.
+
+    \return Entry stored at \a index.
+
+    \pre \a index is below infoCount().
+  */
+  [[nodiscard]] const InfoEntry & infoAt(std::size_t index) const noexcept;
+
+  /// Returns the name of the running case, or \c nullptr before the first beginCase().
+  [[nodiscard]] const char * caseName() const noexcept;
+
+  /// Returns the name of the running subcase, or \c nullptr outside one.
+  [[nodiscard]] const char * subcaseName() const noexcept;
+
+private:
+  failure_reporter_type    _reporter;
+  const char *             _caseName;
+  const char *             _subcaseName;
+  std::size_t              _passedCount;
+  std::size_t              _failedCount;
+  std::size_t              _infoDepth;
+  bool                     _caseFailed;
+  std::array<InfoEntry, 8> _infoStack;
+};
+
 } // namespace toy::test
 
 #include "toy_test.inl"

--- a/tests/runner/toy_test.inl
+++ b/tests/runner/toy_test.inl
@@ -130,4 +130,88 @@ constexpr std::size_t appendInteger(char * buffer, std::size_t capacity, std::si
 
 } // namespace detail
 
+inline Context::Context(failure_reporter_type reporter) noexcept
+  : _reporter{reporter}
+  , _caseName{nullptr}
+  , _subcaseName{nullptr}
+  , _passedCount{0}
+  , _failedCount{0}
+  , _infoDepth{0}
+  , _caseFailed{false}
+  , _infoStack{} {}
+
+inline void Context::beginCase(const char * name) noexcept {
+  _caseName    = name;
+  _subcaseName = nullptr;
+  _caseFailed  = false;
+  _infoDepth   = 0;
+}
+
+inline bool Context::record(bool passed, const char * expression, const char * file, int line) noexcept {
+  if (passed) {
+    ++_passedCount;
+
+    return true;
+  }
+
+  ++_failedCount;
+  _caseFailed = true;
+
+  if (_reporter != nullptr) {
+    const FailureRecord failure{_caseName, _subcaseName, expression, file, line};
+    _reporter(*this, failure);
+  }
+
+  return false;
+}
+
+inline void Context::pushInfo(const char * text) noexcept {
+  if (_infoDepth < _infoStack.size())
+    _infoStack[_infoDepth] = InfoEntry{text, 0, false};
+
+  ++_infoDepth;
+}
+
+inline void Context::pushInfo(const char * text, long long value) noexcept {
+  if (_infoDepth < _infoStack.size())
+    _infoStack[_infoDepth] = InfoEntry{text, value, true};
+
+  ++_infoDepth;
+}
+
+inline void Context::popInfo() noexcept {
+  if (_infoDepth > 0)
+    --_infoDepth;
+}
+
+inline std::size_t Context::passedCount() const noexcept {
+  return _passedCount;
+}
+
+inline std::size_t Context::failedCount() const noexcept {
+  return _failedCount;
+}
+
+inline bool Context::caseFailed() const noexcept {
+  return _caseFailed;
+}
+
+inline std::size_t Context::infoCount() const noexcept {
+  // The depth counter keeps growing past the fixed stack so that pushes and pops stay balanced; what is
+  // readable is capped at the stack itself.
+  return _infoDepth < _infoStack.size() ? _infoDepth : _infoStack.size();
+}
+
+inline const InfoEntry & Context::infoAt(std::size_t index) const noexcept {
+  return _infoStack[index];
+}
+
+inline const char * Context::caseName() const noexcept {
+  return _caseName;
+}
+
+inline const char * Context::subcaseName() const noexcept {
+  return _subcaseName;
+}
+
 } // namespace toy::test

--- a/tests/runner/toy_test.inl
+++ b/tests/runner/toy_test.inl
@@ -166,14 +166,14 @@ inline bool Context::record(bool passed, const char * expression, const char * f
 }
 
 inline void Context::pushInfo(const char * text) noexcept {
-  if (_infoDepth < _infoStack.size())
+  if (_infoDepth < c_maxInfoDepth)
     _infoStack[_infoDepth] = InfoEntry{text, 0, false};
 
   ++_infoDepth;
 }
 
 inline void Context::pushInfo(const char * text, long long value) noexcept {
-  if (_infoDepth < _infoStack.size())
+  if (_infoDepth < c_maxInfoDepth)
     _infoStack[_infoDepth] = InfoEntry{text, value, true};
 
   ++_infoDepth;
@@ -199,7 +199,7 @@ inline bool Context::caseFailed() const noexcept {
 inline std::size_t Context::infoCount() const noexcept {
   // The depth counter keeps growing past the fixed stack so that pushes and pops stay balanced; what is
   // readable is capped at the stack itself.
-  return _infoDepth < _infoStack.size() ? _infoDepth : _infoStack.size();
+  return _infoDepth < c_maxInfoDepth ? _infoDepth : c_maxInfoDepth;
 }
 
 inline const InfoEntry & Context::infoAt(std::size_t index) const noexcept {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nintendo Switch release and shipping packaging support.
  * Enabled the console sample to build and run on Nintendo Switch, including controller input and clean exit handling.
  * Introduced test-runner context support for assertion tracking, failure reporting, case metadata, and informational messages.

* **Bug Fixes**
  * Updated Windows compiler configuration for more consistent x64 and Win32 builds.

* **Tests**
  * Added comprehensive coverage for test context behavior, assertion results, failure details, information handling, and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->