### PR TITLE
test: add built-in test runner macros and case registration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -108,6 +108,7 @@ EmptyLineBeforeAccessModifier: LogicalBlock
 EnumTrailingComma: Insert
 FixNamespaceComments: true
 IncludeBlocks: Regroup
+IncludeIsMainRegex: "^$"
 IncludeCategories:
   - Regex: "^<[^.]+>$"
     Priority: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ Static structure: layers, modules, and where dependencies may point. Directory l
 Style and correctness are enforced by tools, not by review. Configs live at the repo root and CI runs the same checks on changed files; a change is ready when all of them pass clean.
 
 * **Formatting:** `.clang-format` is the sole authority on layout — run it before committing, never hand-format against it. `// clang-format off` only where alignment carries meaning, with a comment saying why.
-* **Include order:** `.clang-format` regroups into blank-line-separated blocks — corresponding header (in a `.cpp`), standard library `<...>`, third-party, project `"..."`.
+* **Include order:** `.clang-format` regroups into blank-line-separated blocks — standard library `<...>`, third-party, project `"..."`.
 * **Static analysis:** checks and options live in `.clang-tidy`; run it over the compile database before committing and review whatever `--fix` changed. Suppress with `// NOLINTNEXTLINE(check)` plus a reason — never a bare `// NOLINT`, never file-wide.
 * **Warnings:** build at the toolchain's warning level and leave none; CI treats them as errors. Fix the code, not the diagnostic — `[[maybe_unused]]` for a deliberately unused parameter.
 * **Language subset:** exceptions and RTTI are off in the build, so `throw`, `dynamic_cast`, and `typeid` fail to compile rather than fail review (see Zero-cost abstractions).

--- a/editor/src/main_menu.mm
+++ b/editor/src/main_menu.mm
@@ -26,9 +26,9 @@
   a responder handles them. Compiled with ARC (see CMakeLists.txt).
 */
 
-#include "main_menu.hpp"
-
 #import <Cocoa/Cocoa.h>
+
+#include "main_menu.hpp"
 
 namespace toy::editor {
 

--- a/editor/src/vulkan_context.cpp
+++ b/editor/src/vulkan_context.cpp
@@ -22,12 +22,12 @@
   \brief  Implementation of \ref toy::editor::VulkanContext.
 */
 
-#include "vulkan_context.hpp"
-
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <vector>
+
+#include "vulkan_context.hpp"
 
 namespace toy::editor {
 

--- a/editor/src/window.mm
+++ b/editor/src/window.mm
@@ -25,10 +25,10 @@
   CAMetalLayer, and pumps native events cooperatively. Compiled with ARC (see CMakeLists.txt).
 */
 
-#include "window.hpp"
-
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/CAMetalLayer.h>
+
+#include "window.hpp"
 
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,7 +63,8 @@ if (TOYGINE_TARGET_PLATFORM_SUPPORT_CTEST)
   include(doctest)
 
   add_executable(${TOYGINE_LIBRARY_NAME}-units ${TESTS_SRC})
-  target_compile_definitions(${TOYGINE_LIBRARY_NAME}-units PRIVATE DOCTEST_CONFIG_SUPER_FAST_ASSERTS)
+  target_compile_definitions(${TOYGINE_LIBRARY_NAME}-units PRIVATE DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+                                                                  TOYGINE_TESTS_USE_DOCTEST)
 
   target_include_directories(${TOYGINE_LIBRARY_NAME}-units PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
   target_include_directories(${TOYGINE_LIBRARY_NAME}-units PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runner)

--- a/tests/runner/approx.hpp
+++ b/tests/runner/approx.hpp
@@ -24,7 +24,8 @@
   Defines \ref toy::test::Approx: a value carrying a relative tolerance, compared through a free \c operator==. Used
   wherever a test asserts a floating-point result, under either runner.
 
-  \note Included by toy_test.hpp only; do not include this file directly.
+  \note Reached through toy_test.hpp; included directly only by the runner's own headers and by the unit test
+        for this type.
 */
 
 #ifndef INCLUDE_TESTS_RUNNER_APPROX_HPP_

--- a/tests/runner/assertion.hpp
+++ b/tests/runner/assertion.hpp
@@ -24,8 +24,8 @@
   Defines the \c TOY_TEST_ASSERT macro and toy::test::detail::assertionFailed(): what a violated precondition does
   inside the runner. Written without \c <cassert> so the runner keeps building on targets that ship no hosted headers.
 
-  \note Reached through toy_test.hpp, and included by the runner's own headers; a test translation unit must not include
-        this file directly.
+  \note Reached through toy_test.hpp; included directly only by the runner's own headers and by the unit test
+        for this type.
 */
 
 #ifndef INCLUDE_TESTS_RUNNER_ASSERTION_HPP_

--- a/tests/runner/case_registrar.hpp
+++ b/tests/runner/case_registrar.hpp
@@ -16,6 +16,7 @@
 // FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
+//
 /*!
   \file   case_registrar.hpp
   \brief  Registration node linking one test case into the runner's name-sorted list.

--- a/tests/runner/case_registrar.hpp
+++ b/tests/runner/case_registrar.hpp
@@ -1,0 +1,130 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+/*!
+  \file   case_registrar.hpp
+  \brief  Registration node linking one test case into the runner's name-sorted list.
+
+  Defines \ref toy::test::CaseRegistrar and \ref toy::test::case_body_type: what the \c TEST_CASE macro constructs as a
+  static object, and what the runner's \c main walks to execute the cases.
+
+  \note Reached through toy_test.hpp, and included by the runner's own headers; a test translation unit must not include
+        this file directly.
+*/
+
+#ifndef INCLUDE_TESTS_RUNNER_CASE_REGISTRAR_HPP_
+#define INCLUDE_TESTS_RUNNER_CASE_REGISTRAR_HPP_
+
+#include "context.hpp"
+#include "utils.hpp"
+
+namespace toy::test {
+
+/// Body of a test case, as produced by the TEST_CASE macro.
+using case_body_type = void (*)(Context & context);
+
+/*!
+  \class CaseRegistrar
+  \brief Static registration node linking one test case into a name-sorted list.
+
+  Constructed as a static object by the \c TEST_CASE macro. Insertion keeps the list ordered by name, so the run order
+  depends only on case names and not on the order of static initialization across translation units, which the standard
+  leaves unspecified.
+
+  \section features Key Features
+
+  * **Allocation-free**: the node is the static object itself, so the registry has no capacity limit
+  * **Deterministic order**: insertion sorts by name at registration time
+  * **Explicit list head**: the list is a parameter, so a test can build an isolated registry
+  * **Non-copyable**: a node belongs to exactly one list
+
+  \section usage Usage Example
+
+  \code
+  static void body(toy::test::Context & context);
+  static toy::test::CaseRegistrar registrar{toy::test::detail::caseListHead, "core/utils/trim", __FILE__, __LINE__,
+                                            &body};
+  \endcode
+
+  \section performance Performance Characteristics
+
+  * **Construction**: O(n) comparisons against the registered cases, so O(n^2) for the whole registry
+  * **Traversal**: O(1) per node
+  * **Memory usage**: 4 pointers plus one int, about 20 bytes on a 32-bit target
+
+  \section safety Safety Guarantees
+
+  * **Contracts**: none; every name is accepted, and duplicates are reported by findDuplicateName()
+  * **Memory safety**: no ownership; the name and file pointers refer to string literals
+  * **Exception safety**: No operation throws; exceptions are off in the build
+
+  \note Registration happens before \c main, so a node must have static storage duration in production use.
+
+  \note A later registration writes the link of an earlier node, so a node must not be \c const.
+
+  \sa \ref toy::test::Context
+*/
+class CaseRegistrar final {
+public:
+  /*!
+    \brief Registers a case into the list rooted at \a head, keeping it sorted by name.
+
+    \param head  List head; updated when the new node sorts first.
+    \param name  Case name; must outlive the run.
+    \param file  Source file declaring the case.
+    \param line  Source line declaring the case.
+    \param body  Case body.
+
+    \post The node is linked into \a head and the list stays ordered by name.
+  */
+  CaseRegistrar(CaseRegistrar *& head, const char * name, const char * file, int line, case_body_type body) noexcept;
+
+  ~CaseRegistrar() noexcept                        = default;
+  CaseRegistrar(const CaseRegistrar &)             = delete;
+  CaseRegistrar & operator=(const CaseRegistrar &) = delete;
+  CaseRegistrar(CaseRegistrar &&)                  = delete;
+  CaseRegistrar & operator=(CaseRegistrar &&)      = delete;
+
+  /// Returns the case name.
+  [[nodiscard]] const char * name() const noexcept;
+
+  /// Returns the source file declaring the case.
+  [[nodiscard]] const char * file() const noexcept;
+
+  /// Returns the source line declaring the case.
+  [[nodiscard]] int line() const noexcept;
+
+  /// Returns the case body.
+  [[nodiscard]] case_body_type body() const noexcept;
+
+  /// Returns the next node in name order, or \c nullptr at the end of the list.
+  [[nodiscard]] const CaseRegistrar * next() const noexcept;
+
+private:
+  const char *    _name;
+  const char *    _file;
+  int             _line;
+  case_body_type  _body;
+  CaseRegistrar * _next{nullptr};
+};
+
+} // namespace toy::test
+
+#include "case_registrar.inl"
+
+#endif // INCLUDE_TESTS_RUNNER_CASE_REGISTRAR_HPP_

--- a/tests/runner/case_registrar.hpp
+++ b/tests/runner/case_registrar.hpp
@@ -24,8 +24,8 @@
   Defines \ref toy::test::CaseRegistrar and \ref toy::test::case_body_type: what the \c TEST_CASE macro constructs as a
   static object, and what the runner's \c main walks to execute the cases.
 
-  \note Reached through toy_test.hpp, and included by the runner's own headers; a test translation unit must not include
-        this file directly.
+  \note Reached through toy_test.hpp; included directly only by the runner's own headers and by the unit test
+        for this type.
 */
 
 #ifndef INCLUDE_TESTS_RUNNER_CASE_REGISTRAR_HPP_

--- a/tests/runner/case_registrar.inl
+++ b/tests/runner/case_registrar.inl
@@ -16,52 +16,49 @@
 // FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
-//
 /*!
-  \file   toy_test.inl
-  \brief  Inline implementations for the case loop, the registry's duplicate-name scan and
-          \ref toy::test::detail::SubcaseGuard.
+  \file   case_registrar.inl
+  \brief  Inline implementations for \ref toy::test::CaseRegistrar: registration and accessors.
 
-  \note Included by toy_test.hpp only; do not include this file directly.
+  \note Included by case_registrar.hpp only; do not include this file directly.
 */
 
 namespace toy::test {
 
-inline void runCase(Context & context, const char * name, case_body_type body) noexcept {
-  context.beginCase(name);
+inline CaseRegistrar::CaseRegistrar(CaseRegistrar *& head, const char * name, const char * file, int line,
+                                    case_body_type body) noexcept
+  : _name{name}
+  , _file{file}
+  , _line{line}
+  , _body{body} {
+  // Insertion sort at registration time: O(n) per node, but it makes the run order depend on names alone.
+  CaseRegistrar ** link = &head;
 
-  std::size_t targetSubcase = 0;
+  while (*link != nullptr && detail::compareNames((*link)->_name, name) < 0)
+    link = &(*link)->_next;
 
-  do {
-    context.beginRun(targetSubcase);
-    body(context);
-    ++targetSubcase;
-  } while (targetSubcase < context.subcaseCount());
+  _next = *link;
+  *link = this;
 }
 
-namespace detail {
-
-inline const CaseRegistrar * findDuplicateName(const CaseRegistrar * head) noexcept {
-  for (const CaseRegistrar * node = head; node != nullptr && node->next() != nullptr; node = node->next())
-    if (compareNames(node->name(), node->next()->name()) == 0)
-      return node;
-
-  return nullptr;
+inline const char * CaseRegistrar::name() const noexcept {
+  return _name;
 }
 
-inline SubcaseGuard::SubcaseGuard(Context & context, const char * name) noexcept
-  : _context{&context}
-  , _entered{context.enterSubcase(name)} {}
-
-inline SubcaseGuard::~SubcaseGuard() noexcept {
-  if (_entered)
-    _context->leaveSubcase();
+inline const char * CaseRegistrar::file() const noexcept {
+  return _file;
 }
 
-inline bool SubcaseGuard::entered() const noexcept {
-  return _entered;
+inline int CaseRegistrar::line() const noexcept {
+  return _line;
 }
 
-} // namespace detail
+inline case_body_type CaseRegistrar::body() const noexcept {
+  return _body;
+}
+
+inline const CaseRegistrar * CaseRegistrar::next() const noexcept {
+  return _next;
+}
 
 } // namespace toy::test

--- a/tests/runner/case_registrar.inl
+++ b/tests/runner/case_registrar.inl
@@ -16,6 +16,7 @@
 // FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
+//
 /*!
   \file   case_registrar.inl
   \brief  Inline implementations for \ref toy::test::CaseRegistrar: registration and accessors.

--- a/tests/runner/context.hpp
+++ b/tests/runner/context.hpp
@@ -24,7 +24,8 @@
   Defines \ref toy::test::Context and \ref toy::test::failure_reporter_type: the counters, the per-case verdict and the
   info stack a reporter reads back. Driven by toy::test::runCase() and read back by whichever runner prints the run.
 
-  \note Included by toy_test.hpp only; do not include this file directly.
+  \note Reached through toy_test.hpp; included directly only by the runner's own headers and by the unit test
+        for this type.
 */
 
 #ifndef INCLUDE_TESTS_RUNNER_CONTEXT_HPP_

--- a/tests/runner/tests/approx.test.cpp
+++ b/tests/runner/tests/approx.test.cpp
@@ -27,7 +27,7 @@
 
 #include <doctest/doctest.h>
 
-#include "toy_test.hpp"
+#include "approx.hpp"
 
 // Approx compares equal within its tolerance and unequal outside it.
 TEST_CASE("test/approx/comparison_honours_tolerance") {

--- a/tests/runner/tests/case_registrar.test.cpp
+++ b/tests/runner/tests/case_registrar.test.cpp
@@ -16,6 +16,7 @@
 // FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
+//
 /*!
   \file   case_registrar.test.cpp
   \brief  Unit tests for \ref toy::test::CaseRegistrar: name-sorted insertion and the fields it carries.

--- a/tests/runner/tests/case_registrar.test.cpp
+++ b/tests/runner/tests/case_registrar.test.cpp
@@ -1,0 +1,110 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+/*!
+  \file   case_registrar.test.cpp
+  \brief  Unit tests for \ref toy::test::CaseRegistrar: name-sorted insertion and the fields it carries.
+*/
+
+#include <doctest/doctest.h>
+
+#include "case_registrar.hpp"
+
+namespace {
+
+void emptyBody(toy::test::Context & context) {
+  static_cast<void>(context);
+}
+
+// A registrar stores the pointers it is handed rather than copying the text, so a case's identity in the list is the
+// literal's address. Comparing addresses asserts that contract and keeps the assertions independent of the name
+// comparison the insertion sort itself runs on.
+constexpr const char * c_alpha = "alpha";
+constexpr const char * c_mike  = "mike";
+constexpr const char * c_zulu  = "zulu";
+
+} // namespace
+
+// Registration order does not survive: the list comes out sorted by name. The three register out of order in both
+// directions, so neither a plain prepend nor a plain append reproduces the expected sequence.
+TEST_CASE("test/case_registrar/insertion_keeps_list_sorted") {
+  toy::test::CaseRegistrar * head = nullptr;
+
+  toy::test::CaseRegistrar second{head, c_mike, "m.cpp", 2, &emptyBody};
+  toy::test::CaseRegistrar third{head, c_zulu, "z.cpp", 3, &emptyBody};
+  toy::test::CaseRegistrar first{head, c_alpha, "a.cpp", 1, &emptyBody};
+
+  // Walking with a cursor keeps a broken link a reported failure: dereferencing a chain would crash the case instead,
+  // and the built-in runner has no signal handler to name the case on a console target.
+  const toy::test::CaseRegistrar * node = head;
+
+  REQUIRE(node != nullptr);
+  REQUIRE(node->name() == c_alpha);
+
+  node = node->next();
+  REQUIRE(node != nullptr);
+  REQUIRE(node->name() == c_mike);
+
+  node = node->next();
+  REQUIRE(node != nullptr);
+  REQUIRE(node->name() == c_zulu);
+
+  REQUIRE(node->next() == nullptr);
+}
+
+// Inserting in alphabetical order gives the same result as inserting in reverse.
+TEST_CASE("test/case_registrar/order_is_independent_of_registration_order") {
+  toy::test::CaseRegistrar * ascending = nullptr;
+
+  toy::test::CaseRegistrar a1{ascending, c_alpha, "a.cpp", 1, &emptyBody};
+  toy::test::CaseRegistrar a2{ascending, c_mike, "m.cpp", 2, &emptyBody};
+  toy::test::CaseRegistrar a3{ascending, c_zulu, "z.cpp", 3, &emptyBody};
+
+  toy::test::CaseRegistrar * descending = nullptr;
+
+  toy::test::CaseRegistrar d1{descending, c_zulu, "z.cpp", 3, &emptyBody};
+  toy::test::CaseRegistrar d2{descending, c_mike, "m.cpp", 2, &emptyBody};
+  toy::test::CaseRegistrar d3{descending, c_alpha, "a.cpp", 1, &emptyBody};
+
+  const toy::test::CaseRegistrar * left  = ascending;
+  const toy::test::CaseRegistrar * right = descending;
+
+  while (left != nullptr && right != nullptr) {
+    REQUIRE(left->name() == right->name());
+    left  = left->next();
+    right = right->next();
+  }
+
+  REQUIRE(left == nullptr);
+  REQUIRE(right == nullptr);
+}
+
+// Every field survives registration, so a report can name the source location.
+TEST_CASE("test/case_registrar/preserves_registered_fields") {
+  constexpr const char * c_caseName = "core/utils/trim";
+  constexpr const char * c_fileName = "tests/core/utils.test.cpp";
+
+  toy::test::CaseRegistrar * head = nullptr;
+
+  toy::test::CaseRegistrar node{head, c_caseName, c_fileName, 42, &emptyBody};
+
+  REQUIRE(node.name() == c_caseName);
+  REQUIRE(node.file() == c_fileName);
+  REQUIRE(node.line() == 42);
+  REQUIRE(node.body() == &emptyBody);
+}

--- a/tests/runner/tests/context.test.cpp
+++ b/tests/runner/tests/context.test.cpp
@@ -27,7 +27,8 @@
 
 #include <doctest/doctest.h>
 
-#include "toy_test.hpp"
+#include "context.hpp"
+#include "utils.hpp"
 
 static_assert(!std::is_copy_constructible_v<toy::test::Context>, "Context must not be copy constructible");
 static_assert(!std::is_copy_assignable_v<toy::test::Context>, "Context must not be copy assignable");

--- a/tests/runner/tests/macros.test.cpp
+++ b/tests/runner/tests/macros.test.cpp
@@ -1,0 +1,173 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   macros.test.cpp
+  \brief  Unit tests for the built-in runner's case, subcase, assertion and info macros.
+*/
+
+#include <cstddef>
+
+#include <doctest/doctest.h>
+
+#include "toy_test.hpp"
+
+namespace {
+
+std::size_t g_subcaseHits[3] = {0, 0, 0};
+std::size_t g_afterRequire   = 0;
+std::size_t g_afterCheck     = 0;
+
+void resetCounters() noexcept {
+  g_afterRequire = 0;
+  g_afterCheck   = 0;
+
+  for (std::size_t index = 0; index < 3; ++index)
+    g_subcaseHits[index] = 0;
+}
+
+// Bodies use the internal macro names, because the short ones belong to doctest inside this binary.
+void bodyWithSubcases(toy::test::Context & toyTestContext) {
+  TOY_TEST_SUBCASE("one") {
+    ++g_subcaseHits[0];
+  }
+  TOY_TEST_SUBCASE("two") {
+    ++g_subcaseHits[1];
+  }
+  TOY_TEST_SUBCASE("three") {
+    ++g_subcaseHits[2];
+  }
+}
+
+void bodyWithFailingRequire(toy::test::Context & toyTestContext) {
+  TOY_TEST_REQUIRE(1 == 2);
+  ++g_afterRequire;
+}
+
+void bodyWithFailingCheck(toy::test::Context & toyTestContext) {
+  TOY_TEST_CHECK(1 == 2);
+  ++g_afterCheck;
+}
+
+void bodyWithInfo(toy::test::Context & toyTestContext) {
+  TOY_TEST_INFO("index", 7);
+  TOY_TEST_CHECK(1 == 2);
+}
+
+void bodyWithNegations(toy::test::Context & toyTestContext) {
+  TOY_TEST_REQUIRE_FALSE(1 == 2);
+  TOY_TEST_CHECK_FALSE(1 == 2);
+  TOY_TEST_REQUIRE(1.0 == toy::test::Approx(1.0));
+}
+
+// The first info entry visible at the moment of the failure, written into storage the reading case owns.
+struct CapturedInfo final {
+  const char * text  = nullptr;
+  long long    value = 0;
+};
+
+void captureInfo(const toy::test::Context & context, const toy::test::FailureRecord & failure,
+                 void * reporterData) noexcept {
+  static_cast<void>(failure);
+
+  if (context.infoCount() > 0) {
+    CapturedInfo & captured = *static_cast<CapturedInfo *>(reporterData);
+
+    captured.text  = context.infoAt(0).text;
+    captured.value = context.infoAt(0).value;
+  }
+}
+
+} // namespace
+
+// A case declared through the macro lands in the registry with its name and source location.
+TOY_TEST_CASE("generated/registered/through_macro") {
+  TOY_TEST_CHECK(1 == 1);
+}
+
+// The registry holds the case the macro above declared.
+TEST_CASE("test/macros/case_macro_registers_the_case") {
+  bool found = false;
+
+  for (const toy::test::CaseRegistrar * node = toy::test::detail::caseListHead; node != nullptr; node = node->next())
+    if (toy::test::detail::compareNames(node->name(), "generated/registered/through_macro") == 0)
+      found = true;
+
+  REQUIRE(found == true);
+}
+
+// The subcase macro produces one run per branch, and each branch executes once.
+TEST_CASE("test/macros/subcase_expands_to_one_run_per_branch") {
+  resetCounters();
+  toy::test::Context context{nullptr};
+
+  toy::test::runCase(context, "generated/case", &bodyWithSubcases);
+
+  REQUIRE(context.subcaseCount() == 3);
+  REQUIRE(g_subcaseHits[0] == 1);
+  REQUIRE(g_subcaseHits[1] == 1);
+  REQUIRE(g_subcaseHits[2] == 1);
+}
+
+// A failed require returns from the body, so nothing after it runs.
+TEST_CASE("test/macros/failing_require_stops_the_body") {
+  resetCounters();
+  toy::test::Context context{nullptr};
+
+  toy::test::runCase(context, "generated/case", &bodyWithFailingRequire);
+
+  REQUIRE(context.failedCount() == 1);
+  REQUIRE(g_afterRequire == 0);
+}
+
+// A failed check records the failure and lets the body continue.
+TEST_CASE("test/macros/failing_check_continues_the_body") {
+  resetCounters();
+  toy::test::Context context{nullptr};
+
+  toy::test::runCase(context, "generated/case", &bodyWithFailingCheck);
+
+  REQUIRE(context.failedCount() == 1);
+  REQUIRE(g_afterCheck == 1);
+}
+
+// An info message reaches the reporter and is gone once the scope ends.
+TEST_CASE("test/macros/info_is_visible_during_failure_only") {
+  resetCounters();
+  CapturedInfo       captured;
+  toy::test::Context context{&captureInfo, &captured};
+
+  toy::test::runCase(context, "generated/case", &bodyWithInfo);
+
+  REQUIRE(captured.text != nullptr);
+  REQUIRE(toy::test::detail::compareNames(captured.text, "index") == 0);
+  REQUIRE(captured.value == 7);
+  REQUIRE(context.infoCount() == 0);
+}
+
+// The negated forms and Approx pass through the macro layer.
+TEST_CASE("test/macros/negated_forms_and_approx") {
+  resetCounters();
+  toy::test::Context context{nullptr};
+
+  toy::test::runCase(context, "generated/case", &bodyWithNegations);
+
+  REQUIRE(context.failedCount() == 0);
+  REQUIRE(context.passedCount() == 3);
+}

--- a/tests/runner/tests/macros.test.cpp
+++ b/tests/runner/tests/macros.test.cpp
@@ -30,14 +30,11 @@
 
 namespace {
 
+// Which branch ran is the one thing the context cannot report: it counts subcases and assertions, never names them.
+// Everything else a case below asserts travels through the context that case owns.
 std::size_t g_subcaseHits[3] = {0, 0, 0};
-std::size_t g_afterRequire   = 0;
-std::size_t g_afterCheck     = 0;
 
-void resetCounters() noexcept {
-  g_afterRequire = 0;
-  g_afterCheck   = 0;
-
+void resetSubcaseHits() noexcept {
   for (std::size_t index = 0; index < 3; ++index)
     g_subcaseHits[index] = 0;
 }
@@ -55,14 +52,15 @@ void bodyWithSubcases(toy::test::Context & toyTestContext) {
   }
 }
 
+// The passing assertion is the witness: it is recorded only if the body reaches the line after the failing one.
 void bodyWithFailingRequire(toy::test::Context & toyTestContext) {
   TOY_TEST_REQUIRE(1 == 2);
-  ++g_afterRequire;
+  TOY_TEST_CHECK(1 == 1);
 }
 
 void bodyWithFailingCheck(toy::test::Context & toyTestContext) {
   TOY_TEST_CHECK(1 == 2);
-  ++g_afterCheck;
+  TOY_TEST_CHECK(1 == 1);
 }
 
 void bodyWithInfo(toy::test::Context & toyTestContext) {
@@ -119,7 +117,7 @@ TEST_CASE("test/macros/case_macro_registers_the_case") {
 
 // The subcase macro produces one run per branch, and each branch executes once.
 TEST_CASE("test/macros/subcase_expands_to_one_run_per_branch") {
-  resetCounters();
+  resetSubcaseHits();
   toy::test::Context context{nullptr};
 
   toy::test::runCase(context, "generated/case", &bodyWithSubcases);
@@ -130,31 +128,28 @@ TEST_CASE("test/macros/subcase_expands_to_one_run_per_branch") {
   REQUIRE(g_subcaseHits[2] == 1);
 }
 
-// A failed require returns from the body, so nothing after it runs.
+// A failed require returns from the body, so the assertion after it is never recorded.
 TEST_CASE("test/macros/failing_require_stops_the_body") {
-  resetCounters();
   toy::test::Context context{nullptr};
 
   toy::test::runCase(context, "generated/case", &bodyWithFailingRequire);
 
   REQUIRE(context.failedCount() == 1);
-  REQUIRE(g_afterRequire == 0);
+  REQUIRE(context.passedCount() == 0);
 }
 
-// A failed check records the failure and lets the body continue.
+// A failed check records the failure and lets the body continue to the assertion after it.
 TEST_CASE("test/macros/failing_check_continues_the_body") {
-  resetCounters();
   toy::test::Context context{nullptr};
 
   toy::test::runCase(context, "generated/case", &bodyWithFailingCheck);
 
   REQUIRE(context.failedCount() == 1);
-  REQUIRE(g_afterCheck == 1);
+  REQUIRE(context.passedCount() == 1);
 }
 
 // An info message reaches the reporter and is gone once the scope ends.
 TEST_CASE("test/macros/info_is_visible_during_failure_only") {
-  resetCounters();
   CapturedInfo       captured;
   toy::test::Context context{&captureInfo, &captured};
 
@@ -168,7 +163,6 @@ TEST_CASE("test/macros/info_is_visible_during_failure_only") {
 
 // The negated forms and Approx pass through the macro layer.
 TEST_CASE("test/macros/negated_forms_and_approx") {
-  resetCounters();
   toy::test::Context context{nullptr};
 
   toy::test::runCase(context, "generated/case", &bodyWithNegations);

--- a/tests/runner/tests/macros.test.cpp
+++ b/tests/runner/tests/macros.test.cpp
@@ -22,6 +22,7 @@
   \brief  Unit tests for the built-in runner's case, subcase, assertion and info macros.
 */
 
+#include <array>
 #include <cstddef>
 
 #include <doctest/doctest.h>
@@ -30,28 +31,8 @@
 
 namespace {
 
-// Which branch ran is the one thing the context cannot report: it counts subcases and assertions, never names them.
-// Everything else a case below asserts travels through the context that case owns.
-std::size_t g_subcaseHits[3] = {0, 0, 0};
-
-void resetSubcaseHits() noexcept {
-  for (std::size_t index = 0; index < 3; ++index)
-    g_subcaseHits[index] = 0;
-}
-
 // Bodies use the internal macro names, because the short ones belong to doctest inside this binary.
-void bodyWithSubcases(toy::test::Context & toyTestContext) {
-  TOY_TEST_SUBCASE("one") {
-    ++g_subcaseHits[0];
-  }
-  TOY_TEST_SUBCASE("two") {
-    ++g_subcaseHits[1];
-  }
-  TOY_TEST_SUBCASE("three") {
-    ++g_subcaseHits[2];
-  }
-}
-
+//
 // The passing assertion is the witness: it is recorded only if the body reaches the line after the failing one.
 void bodyWithFailingRequire(toy::test::Context & toyTestContext) {
   TOY_TEST_REQUIRE(1 == 2);
@@ -115,17 +96,42 @@ TEST_CASE("test/macros/case_macro_registers_the_case") {
   CHECK(registered->line() == c_registeredCaseLine);
 }
 
-// The subcase macro produces one run per branch, and each branch executes once.
+// The subcase macro produces one run per branch, and each branch executes once. The run loop is spelled out here
+// rather than delegated to toy::test::runCase(), because a body it accepts is a bare function pointer and could
+// report which branch ran only through state outside the case.
 TEST_CASE("test/macros/subcase_expands_to_one_run_per_branch") {
-  resetSubcaseHits();
-  toy::test::Context context{nullptr};
+  // The macros reach the run state through a name they choose themselves, so the case declares the context under it.
+  toy::test::Context toyTestContext{nullptr};
+  toyTestContext.beginCase("generated/case");
 
-  toy::test::runCase(context, "generated/case", &bodyWithSubcases);
+  // One more run than the case declares subcases, so a loop that fails to terminate is a failed expectation below
+  // rather than a hung test.
+  constexpr std::size_t c_maxRuns = 4;
 
-  REQUIRE(context.subcaseCount() == 3);
-  REQUIRE(g_subcaseHits[0] == 1);
-  REQUIRE(g_subcaseHits[1] == 1);
-  REQUIRE(g_subcaseHits[2] == 1);
+  std::array<std::size_t, 3> hits{};
+  std::size_t                runCount = 0;
+
+  do {
+    toyTestContext.beginRun(runCount);
+
+    TOY_TEST_SUBCASE("one") {
+      ++hits[0];
+    }
+    TOY_TEST_SUBCASE("two") {
+      ++hits[1];
+    }
+    TOY_TEST_SUBCASE("three") {
+      ++hits[2];
+    }
+
+    ++runCount;
+  } while (runCount < toyTestContext.subcaseCount() && runCount < c_maxRuns);
+
+  REQUIRE(runCount == 3);
+  REQUIRE(toyTestContext.subcaseCount() == 3);
+  REQUIRE(hits[0] == 1);
+  REQUIRE(hits[1] == 1);
+  REQUIRE(hits[2] == 1);
 }
 
 // A failed require returns from the body, so the assertion after it is never recorded.

--- a/tests/runner/tests/macros.test.cpp
+++ b/tests/runner/tests/macros.test.cpp
@@ -96,6 +96,9 @@ void captureInfo(const toy::test::Context & context, const toy::test::FailureRec
 
 } // namespace
 
+// The expected line is captured directly above the declaration, so an edit to the body cannot shift it.
+constexpr int c_registeredCaseLine = __LINE__ + 3;
+
 // A case declared through the macro lands in the registry with its name and source location.
 TOY_TEST_CASE("generated/registered/through_macro") {
   TOY_TEST_CHECK(1 == 1);
@@ -103,13 +106,15 @@ TOY_TEST_CASE("generated/registered/through_macro") {
 
 // The registry holds the case the macro above declared.
 TEST_CASE("test/macros/case_macro_registers_the_case") {
-  bool found = false;
+  const toy::test::CaseRegistrar * registered = nullptr;
 
   for (const toy::test::CaseRegistrar * node = toy::test::detail::caseListHead; node != nullptr; node = node->next())
     if (toy::test::detail::compareNames(node->name(), "generated/registered/through_macro") == 0)
-      found = true;
+      registered = node;
 
-  REQUIRE(found == true);
+  REQUIRE(registered != nullptr);
+  CHECK(toy::test::detail::compareNames(registered->file(), __FILE__) == 0);
+  CHECK(registered->line() == c_registeredCaseLine);
 }
 
 // The subcase macro produces one run per branch, and each branch executes once.

--- a/tests/runner/tests/registry.test.cpp
+++ b/tests/runner/tests/registry.test.cpp
@@ -16,6 +16,7 @@
 // FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
+//
 /*!
   \file   registry.test.cpp
   \brief  Unit tests for the runner's case registry: the duplicate-name scan over a name-sorted list.

--- a/tests/runner/tests/registry.test.cpp
+++ b/tests/runner/tests/registry.test.cpp
@@ -16,10 +16,9 @@
 // FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
-//
 /*!
   \file   registry.test.cpp
-  \brief  Unit tests for \ref toy::test::CaseRegistrar and the runner's name-sorted case registry.
+  \brief  Unit tests for the runner's case registry: the duplicate-name scan over a name-sorted list.
 */
 
 #include <doctest/doctest.h>
@@ -32,87 +31,15 @@ void emptyBody(toy::test::Context & context) {
   static_cast<void>(context);
 }
 
-// A registrar stores the pointers it is handed rather than copying the text, so a case's identity in the list is the
-// literal's address. Comparing addresses asserts that contract and keeps the assertions independent of the name
-// comparison the insertion sort itself runs on.
+// A registrar stores the pointer it is handed rather than copying the text, so a case's identity in the list is the
+// literal's address, and the assertions compare addresses.
 constexpr const char * c_alpha = "alpha";
 constexpr const char * c_bravo = "bravo";
-constexpr const char * c_mike  = "mike";
-constexpr const char * c_zulu  = "zulu";
 
 } // namespace
 
-// Registration order does not survive: the list comes out sorted by name. The three register out of order in both
-// directions, so neither a plain prepend nor a plain append reproduces the expected sequence.
-TEST_CASE("test/case_registrar/insertion_keeps_list_sorted") {
-  toy::test::CaseRegistrar * head = nullptr;
-
-  toy::test::CaseRegistrar second{head, c_mike, "m.cpp", 2, &emptyBody};
-  toy::test::CaseRegistrar third{head, c_zulu, "z.cpp", 3, &emptyBody};
-  toy::test::CaseRegistrar first{head, c_alpha, "a.cpp", 1, &emptyBody};
-
-  // Walking with a cursor keeps a broken link a reported failure: dereferencing a chain would crash the case instead,
-  // and the built-in runner has no signal handler to name the case on a console target.
-  const toy::test::CaseRegistrar * node = head;
-
-  REQUIRE(node != nullptr);
-  REQUIRE(node->name() == c_alpha);
-
-  node = node->next();
-  REQUIRE(node != nullptr);
-  REQUIRE(node->name() == c_mike);
-
-  node = node->next();
-  REQUIRE(node != nullptr);
-  REQUIRE(node->name() == c_zulu);
-
-  REQUIRE(node->next() == nullptr);
-}
-
-// Inserting in alphabetical order gives the same result as inserting in reverse.
-TEST_CASE("test/case_registrar/order_is_independent_of_registration_order") {
-  toy::test::CaseRegistrar * ascending = nullptr;
-
-  toy::test::CaseRegistrar a1{ascending, c_alpha, "a.cpp", 1, &emptyBody};
-  toy::test::CaseRegistrar a2{ascending, c_mike, "m.cpp", 2, &emptyBody};
-  toy::test::CaseRegistrar a3{ascending, c_zulu, "z.cpp", 3, &emptyBody};
-
-  toy::test::CaseRegistrar * descending = nullptr;
-
-  toy::test::CaseRegistrar d1{descending, c_zulu, "z.cpp", 3, &emptyBody};
-  toy::test::CaseRegistrar d2{descending, c_mike, "m.cpp", 2, &emptyBody};
-  toy::test::CaseRegistrar d3{descending, c_alpha, "a.cpp", 1, &emptyBody};
-
-  const toy::test::CaseRegistrar * left  = ascending;
-  const toy::test::CaseRegistrar * right = descending;
-
-  while (left != nullptr && right != nullptr) {
-    REQUIRE(left->name() == right->name());
-    left  = left->next();
-    right = right->next();
-  }
-
-  REQUIRE(left == nullptr);
-  REQUIRE(right == nullptr);
-}
-
-// Every field survives registration, so a report can name the source location.
-TEST_CASE("test/case_registrar/preserves_registered_fields") {
-  constexpr const char * c_caseName = "core/utils/trim";
-  constexpr const char * c_fileName = "tests/core/utils.test.cpp";
-
-  toy::test::CaseRegistrar * head = nullptr;
-
-  toy::test::CaseRegistrar node{head, c_caseName, c_fileName, 42, &emptyBody};
-
-  REQUIRE(node.name() == c_caseName);
-  REQUIRE(node.file() == c_fileName);
-  REQUIRE(node.line() == 42);
-  REQUIRE(node.body() == &emptyBody);
-}
-
 // Two cases sharing a name are neighbours in a sorted list, and the search finds them.
-TEST_CASE("test/case_registrar/duplicate_name_is_found") {
+TEST_CASE("test::detail/find_duplicate_name/finds_the_adjacent_repeat") {
   toy::test::CaseRegistrar * head = nullptr;
 
   toy::test::CaseRegistrar first{head, c_alpha, "a.cpp", 1, &emptyBody};
@@ -127,8 +54,8 @@ TEST_CASE("test/case_registrar/duplicate_name_is_found") {
   REQUIRE(duplicate->next()->name() == c_alpha);
 }
 
-// Distinct names report no duplicate.
-TEST_CASE("test/case_registrar/distinct_names_report_no_duplicate") {
+// Distinct names report nothing.
+TEST_CASE("test::detail/find_duplicate_name/distinct_names_report_none") {
   toy::test::CaseRegistrar * head = nullptr;
 
   toy::test::CaseRegistrar first{head, c_alpha, "a.cpp", 1, &emptyBody};
@@ -137,8 +64,8 @@ TEST_CASE("test/case_registrar/distinct_names_report_no_duplicate") {
   REQUIRE(toy::test::detail::findDuplicateName(head) == nullptr);
 }
 
-// An empty registry is not a duplicate, and neither is a registry of one.
-TEST_CASE("test/case_registrar/empty_and_single_registry_report_no_duplicate") {
+// A list too short to hold a neighbouring pair reports nothing instead of walking off its end.
+TEST_CASE("test::detail/find_duplicate_name/empty_and_single_registry_report_none") {
   REQUIRE(toy::test::detail::findDuplicateName(nullptr) == nullptr);
 
   toy::test::CaseRegistrar * head = nullptr;

--- a/tests/runner/toy_test.hpp
+++ b/tests/runner/toy_test.hpp
@@ -218,7 +218,15 @@ private:
 /// Opens one branch of the running case; see \ref toy::test::detail::SubcaseGuard.
 #define TOY_TEST_SUBCASE(subcaseName) TOY_TEST_SUBCASE_IMPL(subcaseName, TOY_TEST_UNIQUE(toyTestSubcase))
 
-/// Pushes a message shown only if an assertion in this scope fails; see \ref toy::test::detail::InfoGuard.
+/*!
+  \def TOY_TEST_INFO
+  \brief Pushes a message shown only if an assertion in this scope fails.
+
+  Takes a string literal, optionally followed by one integer value; see \ref toy::test::detail::InfoGuard.
+
+  \warning Narrower than doctest's \c INFO, which takes any number of streamable arguments: a call with two strings,
+           or with three arguments, compiles under doctest and fails to compile under the built-in runner.
+*/
 #define TOY_TEST_INFO(...) TOY_TEST_INFO_IMPL(TOY_TEST_UNIQUE(toyTestInfo), __VA_ARGS__)
 
 /// Records an assertion and returns from the case body when it fails.

--- a/tests/runner/toy_test.hpp
+++ b/tests/runner/toy_test.hpp
@@ -21,9 +21,10 @@
   \file   toy_test.hpp
   \brief  Test macros and runner declarations shared by the doctest and built-in test runners.
 
-  Defines \ref toy::test::CaseRegistrar and \ref toy::test::detail::SubcaseGuard, and pulls in the run state, the
-  tolerant comparison and the allocation-free helpers they rest on. Grows into the shim every test translation unit
-  includes in place of doctest; today it carries the pieces that depend on neither runner.
+  Defines the case registry \ref toy::test::detail::caseListHead, \ref toy::test::detail::SubcaseGuard and the case
+  loop, and pulls in the registration node, the run state, the tolerant comparison and the allocation-free helpers they
+  rest on. Grows into the shim every test translation unit includes in place of doctest; today it carries the pieces
+  that depend on neither runner.
 */
 
 #ifndef INCLUDE_TESTS_RUNNER_TOY_TEST_HPP_
@@ -32,13 +33,11 @@
 #include <cstddef>
 
 #include "approx.hpp"
+#include "case_registrar.hpp"
 #include "context.hpp"
 #include "utils.hpp"
 
 namespace toy::test {
-
-/// Body of a test case, as produced by the TEST_CASE macro.
-using case_body_type = void (*)(Context & context);
 
 /*!
   \brief Runs one case, repeating the body once per subcase it declares.
@@ -55,91 +54,6 @@ using case_body_type = void (*)(Context & context);
   \sa \ref toy::test::Context
 */
 void runCase(Context & context, const char * name, case_body_type body) noexcept;
-
-/*!
-  \class CaseRegistrar
-  \brief Static registration node linking one test case into a name-sorted list.
-
-  Constructed as a static object by the \c TEST_CASE macro. Insertion keeps the list ordered by name, so the run order
-  depends only on case names and not on the order of static initialization across translation units, which the standard
-  leaves unspecified.
-
-  \section features Key Features
-
-  * **Allocation-free**: the node is the static object itself, so the registry has no capacity limit
-  * **Deterministic order**: insertion sorts by name at registration time
-  * **Explicit list head**: the list is a parameter, so a test can build an isolated registry
-  * **Non-copyable**: a node belongs to exactly one list
-
-  \section usage Usage Example
-
-  \code
-  static void body(toy::test::Context & context);
-  static toy::test::CaseRegistrar registrar{toy::test::detail::caseListHead, "core/utils/trim", __FILE__, __LINE__,
-                                            &body};
-  \endcode
-
-  \section performance Performance Characteristics
-
-  * **Construction**: O(n) comparisons against the registered cases, so O(n^2) for the whole registry
-  * **Traversal**: O(1) per node
-  * **Memory usage**: 4 pointers plus one int, about 20 bytes on a 32-bit target
-
-  \section safety Safety Guarantees
-
-  * **Contracts**: none; every name is accepted, and duplicates are reported by findDuplicateName()
-  * **Memory safety**: no ownership; the name and file pointers refer to string literals
-  * **Exception safety**: No operation throws; exceptions are off in the build
-
-  \note Registration happens before \c main, so a node must have static storage duration in production use.
-
-  \note A later registration writes the link of an earlier node, so a node must not be \c const.
-
-  \sa \ref toy::test::Context
-*/
-class CaseRegistrar final {
-public:
-  /*!
-    \brief Registers a case into the list rooted at \a head, keeping it sorted by name.
-
-    \param head  List head; updated when the new node sorts first.
-    \param name  Case name; must outlive the run.
-    \param file  Source file declaring the case.
-    \param line  Source line declaring the case.
-    \param body  Case body.
-
-    \post The node is linked into \a head and the list stays ordered by name.
-  */
-  CaseRegistrar(CaseRegistrar *& head, const char * name, const char * file, int line, case_body_type body) noexcept;
-
-  ~CaseRegistrar() noexcept                        = default;
-  CaseRegistrar(const CaseRegistrar &)             = delete;
-  CaseRegistrar & operator=(const CaseRegistrar &) = delete;
-  CaseRegistrar(CaseRegistrar &&)                  = delete;
-  CaseRegistrar & operator=(CaseRegistrar &&)      = delete;
-
-  /// Returns the case name.
-  [[nodiscard]] const char * name() const noexcept;
-
-  /// Returns the source file declaring the case.
-  [[nodiscard]] const char * file() const noexcept;
-
-  /// Returns the source line declaring the case.
-  [[nodiscard]] int line() const noexcept;
-
-  /// Returns the case body.
-  [[nodiscard]] case_body_type body() const noexcept;
-
-  /// Returns the next node in name order, or \c nullptr at the end of the list.
-  [[nodiscard]] const CaseRegistrar * next() const noexcept;
-
-private:
-  const char *    _name;
-  const char *    _file;
-  int             _line;
-  case_body_type  _body;
-  CaseRegistrar * _next;
-};
 
 namespace detail {
 

--- a/tests/runner/toy_test.hpp
+++ b/tests/runner/toy_test.hpp
@@ -136,9 +136,124 @@ private:
   bool      _entered;
 };
 
+/*!
+  \class InfoGuard
+  \brief Scope object pushing one message onto the context's info stack.
+
+  Constructed by the info macro; the message is printed only when an assertion inside the scope fails.
+
+  \section features Key Features
+
+  * **Allocation-free**: the message is a pointer to a literal, and the stack has a fixed depth
+  * **Scope-bound**: the entry disappears when the scope ends
+  * **Non-copyable**: the scope owns the pushed entry
+
+  \section usage Usage Example
+
+  \code
+  INFO("index", index);
+  CHECK(values[index] == 0);
+  \endcode
+
+  \section performance Performance Characteristics
+
+  * **Construction**: O(1) constant time
+  * **Destruction**: O(1) constant time
+  * **Memory usage**: one pointer
+
+  \section safety Safety Guarantees
+
+  * **Contracts**: none; a push past the fixed depth is dropped, not asserted
+  * **Memory safety**: no ownership of the text, which must outlive the scope
+  * **Exception safety**: No operation throws; exceptions are off in the build
+
+  \sa \ref toy::test::Context
+*/
+class InfoGuard final {
+public:
+  /// Pushes a message without a companion value; see toy::test::Context::pushInfo().
+  InfoGuard(Context & context, const char * text) noexcept;
+
+  /// Pushes a message carrying a number; see toy::test::Context::pushInfo().
+  InfoGuard(Context & context, const char * text, long long value) noexcept;
+
+  ~InfoGuard() noexcept;
+
+  InfoGuard(const InfoGuard &)             = delete;
+  InfoGuard & operator=(const InfoGuard &) = delete;
+  InfoGuard(InfoGuard &&)                  = delete;
+  InfoGuard & operator=(InfoGuard &&)      = delete;
+
+private:
+  Context * _context;
+};
+
 } // namespace detail
 
 } // namespace toy::test
+
+// Two levels of indirection are what makes __COUNTER__ expand before it is pasted.
+#define TOY_TEST_CONCAT_INNER(lhs, rhs) lhs##rhs
+#define TOY_TEST_CONCAT(lhs, rhs)       TOY_TEST_CONCAT_INNER(lhs, rhs)
+#define TOY_TEST_UNIQUE(prefix)         TOY_TEST_CONCAT(prefix, __COUNTER__)
+
+// The registrar is not const: a later registration writes the link of an earlier node, see toy::test::CaseRegistrar.
+#define TOY_TEST_CASE_IMPL(caseName, bodyName, registrarName)                                                          \
+  static void                       bodyName(::toy::test::Context & toyTestContext);                                   \
+  static ::toy::test::CaseRegistrar registrarName{::toy::test::detail::caseListHead, caseName, __FILE__, __LINE__,     \
+                                                  &bodyName};                                                          \
+  static void                       bodyName(::toy::test::Context & toyTestContext)
+
+#define TOY_TEST_SUBCASE_IMPL(subcaseName, guardName)                                                                  \
+  if (const ::toy::test::detail::SubcaseGuard guardName{toyTestContext, subcaseName}; guardName.entered())
+
+#define TOY_TEST_INFO_IMPL(guardName, ...)                                                                             \
+  const ::toy::test::detail::InfoGuard guardName {                                                                     \
+    toyTestContext, __VA_ARGS__                                                                                        \
+  }
+
+/// Declares and registers a test case; see \ref toy::test::CaseRegistrar.
+#define TOY_TEST_CASE(caseName) TOY_TEST_CASE_IMPL(caseName, TOY_TEST_UNIQUE(toyTestBody), TOY_TEST_UNIQUE(toyTestReg))
+
+/// Opens one branch of the running case; see \ref toy::test::detail::SubcaseGuard.
+#define TOY_TEST_SUBCASE(subcaseName) TOY_TEST_SUBCASE_IMPL(subcaseName, TOY_TEST_UNIQUE(toyTestSubcase))
+
+/// Pushes a message shown only if an assertion in this scope fails; see \ref toy::test::detail::InfoGuard.
+#define TOY_TEST_INFO(...) TOY_TEST_INFO_IMPL(TOY_TEST_UNIQUE(toyTestInfo), __VA_ARGS__)
+
+/// Records an assertion and returns from the case body when it fails.
+#define TOY_TEST_REQUIRE(expression)                                                                                   \
+  do {                                                                                                                 \
+    if (!toyTestContext.record(static_cast<bool>(expression), #expression, __FILE__, __LINE__)) {                      \
+      return;                                                                                                          \
+    }                                                                                                                  \
+  } while (false)
+
+/// Records an assertion and continues regardless of the outcome.
+#define TOY_TEST_CHECK(expression)                                                                                     \
+  static_cast<void>(toyTestContext.record(static_cast<bool>(expression), #expression, __FILE__, __LINE__))
+
+/// Negated form of the returning assertion.
+#define TOY_TEST_REQUIRE_FALSE(expression) TOY_TEST_REQUIRE(!(expression))
+
+/// Negated form of the continuing assertion.
+#define TOY_TEST_CHECK_FALSE(expression) TOY_TEST_CHECK(!(expression))
+
+#if defined(TOYGINE_TESTS_USE_DOCTEST)
+
+#include <doctest/doctest.h>
+
+#else
+
+#define TEST_CASE(caseName)       TOY_TEST_CASE(caseName)
+#define SUBCASE(subcaseName)      TOY_TEST_SUBCASE(subcaseName)
+#define REQUIRE(expression)       TOY_TEST_REQUIRE(expression)
+#define REQUIRE_FALSE(expression) TOY_TEST_REQUIRE_FALSE(expression)
+#define CHECK(expression)         TOY_TEST_CHECK(expression)
+#define CHECK_FALSE(expression)   TOY_TEST_CHECK_FALSE(expression)
+#define INFO(...)                 TOY_TEST_INFO(__VA_ARGS__)
+
+#endif // TOYGINE_TESTS_USE_DOCTEST
 
 #include "toy_test.inl"
 

--- a/tests/runner/toy_test.inl
+++ b/tests/runner/toy_test.inl
@@ -62,6 +62,20 @@ inline bool SubcaseGuard::entered() const noexcept {
   return _entered;
 }
 
+inline InfoGuard::InfoGuard(Context & context, const char * text) noexcept
+  : _context{&context} {
+  context.pushInfo(text);
+}
+
+inline InfoGuard::InfoGuard(Context & context, const char * text, long long value) noexcept
+  : _context{&context} {
+  context.pushInfo(text, value);
+}
+
+inline InfoGuard::~InfoGuard() noexcept {
+  _context->popInfo();
+}
+
 } // namespace detail
 
 } // namespace toy::test

--- a/tests/runner/utils.hpp
+++ b/tests/runner/utils.hpp
@@ -25,8 +25,8 @@
   toy::test::detail::appendInteger(): what \c <cmath>, \c <cstring> and \c <charconv> would provide, written so the
   runner builds on targets whose standard library ships none of them.
 
-  \note Reached through toy_test.hpp, and included by the runner's own headers; a test translation unit must not include
-        this file directly.
+  \note Reached through toy_test.hpp; included directly only by the runner's own headers and by the unit test
+        for this type.
 */
 
 #ifndef INCLUDE_TESTS_RUNNER_UTILS_HPP_


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded the built-in test runner with test-case registration, subcases, informational messages, assertion controls, negated assertions, and approximate comparisons.
  - Added coverage for registration ordering, duplicate names, metadata preservation, and runner behavior.
  - Improved test isolation by allowing focused components to be tested independently.

- **Chores**
  - Standardized include ordering and formatting configuration.
  - Clarified testing documentation and header usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->