### PR TITLE
feat(samples): add Wii U console sample

### DIFF
--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -130,6 +130,7 @@ jobs:
             container: ghcr.io/toymaninteractive/toygine2.wiiu.toolchain:latest
             run_test: "false"
             cmake_preset: wii-u-release
+            artifact_id: wii-u
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -63,8 +63,8 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
       string(APPEND CMAKE_C_FLAGS   " /arch:SSE2 /fpcvt:IA")
       string(APPEND CMAKE_CXX_FLAGS " /arch:SSE2 /fpcvt:IA")
 
-      string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          " /favor:blend /Gv")
-      string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        " /favor:blend /Gv")
+      string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          " /favor:blend /Gv /homeparams")
+      string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        " /favor:blend /Gv /homeparams")
 
       string(APPEND CMAKE_C_FLAGS_RELEASE                 " /favor:blend /Gv")
       string(APPEND CMAKE_CXX_FLAGS_RELEASE               " /favor:blend /Gv")

--- a/samples/console/CMakeLists.txt
+++ b/samples/console/CMakeLists.txt
@@ -58,6 +58,12 @@ elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo Wii")
 
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/console_sample_app.dol" DESTINATION bin COMPONENT samples)
 
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo Wii U")
+
+  wut_create_rpx(console_sample_app)
+
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/console_sample_app.rpx" DESTINATION bin COMPONENT samples)
+
 else ()
 
   install(TARGETS console_sample_app RUNTIME DESTINATION bin COMPONENT samples)

--- a/samples/console/console_sample_app.cpp
+++ b/samples/console/console_sample_app.cpp
@@ -191,8 +191,38 @@ int main() {
 
 #endif // __wii__
 
+#ifdef __WIIU__
+
+#include <coreinit/thread.h>
+#include <coreinit/time.h>
+#include <whb/log.h>
+#include <whb/log_console.h>
+#include <whb/proc.h>
+
+int main(int argc, char ** argv) {
+  WHBProcInit();
+  WHBLogConsoleInit();
+  WHBLogPrintf("Hello world from Console sample app");
+
+  while (WHBProcIsRunning()) {
+    WHBLogConsoleDraw();
+    OSSleepTicks(OSMillisecondsToTicks(100));
+  }
+
+  WHBLogPrintf("Exiting... good bye.");
+  WHBLogConsoleDraw();
+  OSSleepTicks(OSMillisecondsToTicks(1000));
+
+  WHBLogConsoleFree();
+  WHBProcShutdown();
+
+  return 0;
+}
+
+#endif // __WIIU__
+
 #if !defined(__GBA__) && !defined(__NDS__) && !defined(__3DS__) && !defined(__SWITCH__) && !defined(__gamecube__)      \
-  && !defined(__wii__)
+  && !defined(__wii__) && !defined(__WIIU__)
 
 #include <iostream>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,14 @@ if (TOYGINE_TARGET_PLATFORM_SUPPORT_CTEST)
   target_link_libraries(${TOYGINE_LIBRARY_NAME}-units PRIVATE doctest::doctest ${TOYGINE_LIBRARY_NAME})
   doctest_discover_tests(${TOYGINE_LIBRARY_NAME}-units)
 
+  # The runner's own translation units: its entry point and the platform sink. Nothing links them until task 7 builds
+  # the tests with them, so compiling them as objects is what keeps a broken entry point from surviving until then.
+  # Task 8 moves the sink's platform choice out of this desktop-only guard.
+  add_library(${TOYGINE_LIBRARY_NAME}-runner OBJECT
+      ${CMAKE_CURRENT_SOURCE_DIR}/runner/toy_test.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/runner/sink_desktop.cpp)
+  target_include_directories(${TOYGINE_LIBRARY_NAME}-runner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runner)
+
   # CodeCoverage aborts on anything but a gcov-compatible toolchain, so keep the option a no-op elsewhere (MSVC)
   set(TOYGINE_COMPILER_SUPPORT_COVERAGE OFF)
   if (CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|(Apple)?[Cc]lang)$")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,8 +63,7 @@ if (TOYGINE_TARGET_PLATFORM_SUPPORT_CTEST)
   include(doctest)
 
   add_executable(${TOYGINE_LIBRARY_NAME}-units ${TESTS_SRC})
-  target_compile_definitions(${TOYGINE_LIBRARY_NAME}-units PRIVATE DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-                                                                  TOYGINE_TESTS_USE_DOCTEST)
+  target_compile_definitions(${TOYGINE_LIBRARY_NAME}-units PRIVATE DOCTEST_CONFIG_SUPER_FAST_ASSERTS TOYGINE_TESTS_USE_DOCTEST)
 
   target_include_directories(${TOYGINE_LIBRARY_NAME}-units PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
   target_include_directories(${TOYGINE_LIBRARY_NAME}-units PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runner)

--- a/tests/runner/report.hpp
+++ b/tests/runner/report.hpp
@@ -64,7 +64,7 @@ namespace detail {
   * **Allocation-free**: one fixed buffer, no container and no heap
   * **Freestanding**: formats integers and text without \c <cstdio> or \c <charconv>
   * **Verdict once**: writeVerdict() prints the entry for a case at most once
-  * **Truncating**: a line past the buffer is cut, never overflowed
+  * **Truncating**: a line past the buffer is cut and still terminated, never overflowed
 
   \section usage Usage Example
 
@@ -139,7 +139,10 @@ public:
   /*!
     \brief Terminates the line and hands it to the writer.
 
-    \post The line buffer is empty; the writer has been called exactly once.
+    \post The line buffer is empty; the writer has been called exactly once with a line ending in a newline.
+
+    \note A line filled to the capacity loses its last byte to the terminator, so every line the writer receives ends
+          in a newline whatever was appended to it.
   */
   void flush() noexcept;
 

--- a/tests/runner/report.hpp
+++ b/tests/runner/report.hpp
@@ -1,0 +1,221 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   report.hpp
+  \brief  Writer of the TOYTEST report shared by every runner binary.
+
+  Defines \ref toy::test::write_function_type and \ref toy::test::detail::ReportWriter: the line buffer and the walk
+  over a case registry that turn a run into text. Sits on top of toy_test.hpp rather than inside it, because output is
+  what consumes the runner, not part of it. Used by the runner's entry point and by its unit test, which reads the
+  report back through a writer of its own.
+*/
+
+#ifndef INCLUDE_TESTS_RUNNER_REPORT_HPP_
+#define INCLUDE_TESTS_RUNNER_REPORT_HPP_
+
+#include <cstddef>
+
+#include "toy_test.hpp"
+
+namespace toy::test {
+
+/*!
+  \brief Function receiving the report one line at a time.
+
+  \param text        Bytes to write; not null-terminated and ending in a newline.
+  \param length      Number of bytes.
+  \param writerData  Pointer handed to toy::test::writeReport(); \c nullptr when none was given.
+
+  \note A writer is a plain function pointer, so a destination it must remember between calls arrives through
+        \a writerData rather than through storage of its own.
+
+  \sa \ref toy::test::detail::ReportWriter
+*/
+using write_function_type = void (*)(const char * text, std::size_t length, void * writerData) noexcept;
+
+namespace detail {
+
+/*!
+  \class ReportWriter
+  \brief Line buffer and per-case verdict state of the TOYTEST report.
+
+  Builds one line at a time in a fixed buffer and hands it to the writer given at construction. Also holds the running
+  case, so the verdict line prints once however many failures the case records.
+
+  \section features Key Features
+
+  * **Allocation-free**: one fixed buffer, no container and no heap
+  * **Freestanding**: formats integers and text without \c <cstdio> or \c <charconv>
+  * **Verdict once**: writeVerdict() prints the entry for a case at most once
+  * **Truncating**: a line past the buffer is cut, never overflowed
+
+  \section usage Usage Example
+
+  \code
+  toy::test::detail::ReportWriter writer{&write, &destination};
+
+  writer.beginCase(1, "core/fixed_string/append");
+  writer.writeVerdict(false);
+  \endcode
+
+  \section performance Performance Characteristics
+
+  * **Construction**: O(1) constant time
+  * **addText()**: O(n) in the text length
+  * **Memory usage**: 256-byte line buffer plus five words
+
+  \section safety Safety Guarantees
+
+  * **Contracts**: none; a line past the capacity is truncated, not asserted
+  * **Bounds safety**: every append stops at the buffer's capacity
+  * **Memory safety**: no ownership of the case name, which must outlive the run
+  * **Exception safety**: No operation throws; exceptions are off in the build
+
+  \note Every line the writer emits ends in a newline, so a writer may treat one call as one line.
+
+  \sa \ref toy::test::write_function_type
+*/
+class ReportWriter final {
+public:
+  /// Capacity of one report line in bytes; a longer line is truncated.
+  static constexpr std::size_t c_lineCapacity = 256;
+
+  /*!
+    \brief Builds a writer emitting through \a write.
+
+    \param write       Function receiving each finished line; must not be \c nullptr.
+    \param writerData  Storage handed back to \a write on every call; owned by the caller, which must outlive the
+                       writer.
+
+    \post The line buffer is empty and no case is running.
+  */
+  ReportWriter(write_function_type write, void * writerData) noexcept;
+
+  ~ReportWriter() noexcept                       = default;
+  ReportWriter(const ReportWriter &)             = delete;
+  ReportWriter & operator=(const ReportWriter &) = delete;
+  ReportWriter(ReportWriter &&)                  = delete;
+  ReportWriter & operator=(ReportWriter &&)      = delete;
+
+  /*!
+    \brief Appends text to the line being built.
+
+    \param text  Null-terminated text.
+
+    \post The line grows by the text, or stops at the capacity.
+
+    \sa addInteger()
+  */
+  void addText(const char * text) noexcept;
+
+  /*!
+    \brief Appends a signed decimal number to the line being built.
+
+    \param value  Value to format.
+
+    \post The line grows by the digits, or stops at the capacity.
+
+    \sa addText()
+  */
+  void addInteger(long long value) noexcept;
+
+  /*!
+    \brief Terminates the line and hands it to the writer.
+
+    \post The line buffer is empty; the writer has been called exactly once.
+  */
+  void flush() noexcept;
+
+  /*!
+    \brief Starts a case and clears its verdict.
+
+    \param number  Position of the case in the run, counted from one.
+    \param name    Case name; must outlive the run.
+
+    \post writeVerdict() will print an entry for this case.
+  */
+  void beginCase(std::size_t number, const char * name) noexcept;
+
+  /*!
+    \brief Prints the entry of the running case unless it is already printed.
+
+    \param failed  \c true for a \c "not ok" entry, \c false for an \c "ok" one.
+
+    \post The running case has an entry; a later call prints nothing.
+
+    \note A case failing after its entry is printed keeps the verdict of the first call, which is why the failing
+          caller prints first and the passing one last.
+
+    \sa beginCase()
+  */
+  void writeVerdict(bool failed) noexcept;
+
+private:
+  write_function_type _write;
+  void *              _writerData;
+  const char *        _caseName{nullptr};
+  std::size_t         _caseNumber{0};
+  bool                _caseReported{false};
+  char                _buffer[c_lineCapacity]{};
+  std::size_t         _length{0};
+};
+
+/*!
+  \brief Writes the block describing one failed assertion.
+
+  \param context       Context that recorded the failure; read for the info stack.
+  \param failure       The failed assertion.
+  \param reporterData  The \ref toy::test::detail::ReportWriter the report is built with.
+
+  \note Matches \ref toy::test::failure_reporter_type, so toy::test::writeReport() installs it into the context it
+        drives the run with.
+*/
+void reportFailure(const Context & context, const FailureRecord & failure, void * reporterData) noexcept;
+
+} // namespace detail
+
+/*!
+  \brief Runs every case in a registry and writes the TOYTEST report.
+
+  Prints the format line, one entry per case in registry order, the plan line and the summary. A repeated case name
+  aborts the run before any body executes, because two cases sharing a name cannot be told apart in a report.
+
+  \param write       Function receiving each line of the report; must not be \c nullptr.
+  \param writerData  Storage handed back to \a write on every call; may be \c nullptr.
+  \param head        Head of a name-sorted case registry; \c nullptr runs no case.
+
+  \return \c 0 when every assertion passed, \c 1 on any failure or a nested subcase, \c 2 on a duplicate case name.
+
+  \post Every case in the registry has run, unless a duplicate name aborted the run.
+
+  \note Allocates nothing and touches no global state: the run state and the line buffer are local, so two reports can
+        be written in one process.
+
+  \note Deterministic — the report depends on the registry order and the case bodies, never on link order or timing.
+
+  \sa \ref toy::test::write_function_type
+*/
+[[nodiscard]] int writeReport(write_function_type write, void * writerData, const CaseRegistrar * head) noexcept;
+
+} // namespace toy::test
+
+#include "report.inl"
+
+#endif // INCLUDE_TESTS_RUNNER_REPORT_HPP_

--- a/tests/runner/report.inl
+++ b/tests/runner/report.inl
@@ -1,0 +1,165 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   report.inl
+  \brief  Inline implementations for \ref toy::test::detail::ReportWriter and the run that writes the report.
+
+  \note Included by report.hpp only; do not include this file directly.
+*/
+
+namespace toy::test {
+
+namespace detail {
+
+inline ReportWriter::ReportWriter(write_function_type write, void * writerData) noexcept
+  : _write{write}
+  , _writerData{writerData} {}
+
+inline void ReportWriter::addText(const char * text) noexcept {
+  _length = appendText(_buffer, c_lineCapacity, _length, text);
+}
+
+inline void ReportWriter::addInteger(long long value) noexcept {
+  _length = appendInteger(_buffer, c_lineCapacity, _length, value);
+}
+
+inline void ReportWriter::flush() noexcept {
+  addText("\n");
+
+  _write(_buffer, _length, _writerData);
+
+  _length = 0;
+}
+
+inline void ReportWriter::beginCase(std::size_t number, const char * name) noexcept {
+  _caseName     = name;
+  _caseNumber   = number;
+  _caseReported = false;
+}
+
+inline void ReportWriter::writeVerdict(bool failed) noexcept {
+  if (_caseReported)
+    return;
+
+  _caseReported = true;
+
+  addText(failed ? "not ok " : "ok ");
+  addInteger(static_cast<long long>(_caseNumber));
+  addText(" - ");
+  addText(_caseName);
+
+  flush();
+}
+
+inline void reportFailure(const Context & context, const FailureRecord & failure, void * reporterData) noexcept {
+  ReportWriter & writer = *static_cast<ReportWriter *>(reporterData);
+
+  // The header prints once per case, so several failures in one case stay under one entry.
+  writer.writeVerdict(true);
+
+  writer.addText("  file: ");
+  writer.addText(failure.file);
+  writer.flush();
+
+  writer.addText("  line: ");
+  writer.addInteger(failure.line);
+  writer.flush();
+
+  writer.addText("  expr: ");
+  writer.addText(failure.expression);
+  writer.flush();
+
+  if (failure.subcaseName != nullptr) {
+    writer.addText("  subcase: ");
+    writer.addText(failure.subcaseName);
+    writer.flush();
+  }
+
+  for (std::size_t index = 0; index < context.infoCount(); ++index) {
+    const InfoEntry & entry = context.infoAt(index);
+
+    writer.addText("  info: ");
+    writer.addText(entry.text);
+
+    if (entry.hasValue) {
+      writer.addText(": ");
+      writer.addInteger(entry.value);
+    }
+
+    writer.flush();
+  }
+}
+
+} // namespace detail
+
+inline int writeReport(write_function_type write, void * writerData, const CaseRegistrar * head) noexcept {
+  detail::ReportWriter writer{write, writerData};
+
+  writer.addText("TOYTEST 1");
+  writer.flush();
+
+  const CaseRegistrar * duplicate = detail::findDuplicateName(head);
+
+  if (duplicate != nullptr) {
+    writer.addText("TOYTEST ERROR duplicate case name: ");
+    writer.addText(duplicate->name());
+    writer.flush();
+
+    return 2;
+  }
+
+  Context context{&detail::reportFailure, &writer};
+
+  std::size_t caseCount  = 0;
+  bool        nestedSeen = false;
+
+  for (const CaseRegistrar * node = head; node != nullptr; node = node->next()) {
+    ++caseCount;
+    writer.beginCase(caseCount, node->name());
+
+    runCase(context, node->name(), node->body());
+
+    // A nested subcase condemns the case, so the entry must read "not ok" even when every assertion passed.
+    if (context.nestedSubcaseDetected()) {
+      nestedSeen = true;
+
+      writer.writeVerdict(true);
+      writer.addText("  error: nested subcase");
+      writer.flush();
+    }
+
+    // Prints only for a case that reached here without a failure, since the verdict is already written otherwise.
+    writer.writeVerdict(false);
+  }
+
+  writer.addText("1..");
+  writer.addInteger(static_cast<long long>(caseCount));
+  writer.flush();
+
+  writer.addText("TOYTEST SUMMARY passed=");
+  writer.addInteger(static_cast<long long>(context.passedCount()));
+  writer.addText(" failed=");
+  writer.addInteger(static_cast<long long>(context.failedCount()));
+  writer.flush();
+
+  return context.failedCount() != 0 || nestedSeen ? 1 : 0;
+}
+
+} // namespace toy::test

--- a/tests/runner/report.inl
+++ b/tests/runner/report.inl
@@ -41,7 +41,11 @@ inline void ReportWriter::addInteger(long long value) noexcept {
 }
 
 inline void ReportWriter::flush() noexcept {
-  addText("\n");
+  if (_length == c_lineCapacity)
+    --_length;
+
+  _buffer[_length] = '\n';
+  ++_length;
 
   _write(_buffer, _length, _writerData);
 

--- a/tests/runner/sink_desktop.cpp
+++ b/tests/runner/sink_desktop.cpp
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   sink_desktop.cpp
+  \brief  Output and exit for Windows, Linux and macOS: standard output and the process exit code.
+*/
+
+#include <cstdio>
+#include <cstdlib>
+
+#include "toy_test.hpp"
+
+namespace toy::test {
+
+void platformWrite(const char * text, std::size_t length) noexcept {
+  std::fwrite(text, 1, length, stdout);
+}
+
+void platformExit(int code) noexcept {
+  std::fflush(stdout);
+
+  std::exit(code);
+}
+
+} // namespace toy::test

--- a/tests/runner/tests/report.test.cpp
+++ b/tests/runner/tests/report.test.cpp
@@ -23,6 +23,7 @@
 */
 
 #include <cstddef>
+#include <cstring>
 
 #include <doctest/doctest.h>
 
@@ -87,7 +88,23 @@ void bodyFailsInsideSubcase(toy::test::Context & toyTestContext) {
   }
 }
 
+// Compares exactly the bytes the writer handed over, then requires the expected text to end there too: a report that
+// merely starts with the expected text is not the expected report. Comparing to the terminator instead would ignore
+// the captured length and pass a report whose writer miscounted it.
+[[nodiscard]] bool reportMatches(const CapturedReport & captured, const char * expected) noexcept {
+  return std::strncmp(captured.text, expected, captured.length) == 0 && expected[captured.length] == '\0';
+}
+
 } // namespace
+
+// Puts both texts into the failure message, because a comparison folded into a bool reports only that they differ,
+// and the whole point of comparing the report in full is to see where it went wrong.
+#define REQUIRE_REPORT(captured, expected)                                                                             \
+  do {                                                                                                                 \
+    INFO("actual:\n" << (captured).text);                                                                              \
+    INFO("expected:\n" << (expected));                                                                                 \
+    REQUIRE(reportMatches((captured), (expected)));                                                                    \
+  } while (false)
 
 // A run without a failure prints one entry per case, the plan line, the summary, and reports success.
 TEST_CASE("test/write_report/passing_run_prints_an_entry_per_case") {
@@ -101,12 +118,11 @@ TEST_CASE("test/write_report/passing_run_prints_an_entry_per_case") {
   const int code = toy::test::writeReport(&captureWrite, &captured, head);
 
   REQUIRE(code == 0);
-  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
-                                                         "ok 1 - sample/a/first\n"
-                                                         "ok 2 - sample/b/second\n"
-                                                         "1..2\n"
-                                                         "TOYTEST SUMMARY passed=2 failed=0\n")
-          == 0);
+  REQUIRE_REPORT(captured, "TOYTEST 1\n"
+                           "ok 1 - sample/a/first\n"
+                           "ok 2 - sample/b/second\n"
+                           "1..2\n"
+                           "TOYTEST SUMMARY passed=2 failed=0\n");
 }
 
 // Two failures in one case share a single header and each print their own location block.
@@ -120,17 +136,16 @@ TEST_CASE("test/write_report/failures_share_one_case_header") {
   const int code = toy::test::writeReport(&captureWrite, &captured, head);
 
   REQUIRE(code == 1);
-  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
-                                                         "not ok 1 - sample/fails\n"
-                                                         "  file: first.cpp\n"
-                                                         "  line: 11\n"
-                                                         "  expr: 1 == 2\n"
-                                                         "  file: second.cpp\n"
-                                                         "  line: 22\n"
-                                                         "  expr: 2 == 3\n"
-                                                         "1..1\n"
-                                                         "TOYTEST SUMMARY passed=0 failed=2\n")
-          == 0);
+  REQUIRE_REPORT(captured, "TOYTEST 1\n"
+                           "not ok 1 - sample/fails\n"
+                           "  file: first.cpp\n"
+                           "  line: 11\n"
+                           "  expr: 1 == 2\n"
+                           "  file: second.cpp\n"
+                           "  line: 22\n"
+                           "  expr: 2 == 3\n"
+                           "1..1\n"
+                           "TOYTEST SUMMARY passed=0 failed=2\n");
 }
 
 // Three branches give three runs of the body, so the summary counts three passing assertions under one entry.
@@ -144,11 +159,10 @@ TEST_CASE("test/write_report/subcases_run_once_each_under_one_entry") {
   const int code = toy::test::writeReport(&captureWrite, &captured, head);
 
   REQUIRE(code == 0);
-  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
-                                                         "ok 1 - sample/subcases\n"
-                                                         "1..1\n"
-                                                         "TOYTEST SUMMARY passed=3 failed=0\n")
-          == 0);
+  REQUIRE_REPORT(captured, "TOYTEST 1\n"
+                           "ok 1 - sample/subcases\n"
+                           "1..1\n"
+                           "TOYTEST SUMMARY passed=3 failed=0\n");
 }
 
 // A nested subcase condemns its case even though no assertion failed, and the run reports failure.
@@ -162,12 +176,11 @@ TEST_CASE("test/write_report/nested_subcase_condemns_the_case") {
   const int code = toy::test::writeReport(&captureWrite, &captured, head);
 
   REQUIRE(code == 1);
-  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
-                                                         "not ok 1 - sample/nested\n"
-                                                         "  error: nested subcase\n"
-                                                         "1..1\n"
-                                                         "TOYTEST SUMMARY passed=0 failed=0\n")
-          == 0);
+  REQUIRE_REPORT(captured, "TOYTEST 1\n"
+                           "not ok 1 - sample/nested\n"
+                           "  error: nested subcase\n"
+                           "1..1\n"
+                           "TOYTEST SUMMARY passed=0 failed=0\n");
 }
 
 // The subcase and the info entries live at the moment of the failure, so both reach the block under it.
@@ -181,16 +194,15 @@ TEST_CASE("test/write_report/failure_block_carries_subcase_and_info") {
   const int code = toy::test::writeReport(&captureWrite, &captured, head);
 
   REQUIRE(code == 1);
-  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
-                                                         "not ok 1 - sample/info\n"
-                                                         "  file: info.cpp\n"
-                                                         "  line: 33\n"
-                                                         "  expr: values[index] == 0\n"
-                                                         "  subcase: branch\n"
-                                                         "  info: index: 7\n"
-                                                         "1..1\n"
-                                                         "TOYTEST SUMMARY passed=0 failed=1\n")
-          == 0);
+  REQUIRE_REPORT(captured, "TOYTEST 1\n"
+                           "not ok 1 - sample/info\n"
+                           "  file: info.cpp\n"
+                           "  line: 33\n"
+                           "  expr: values[index] == 0\n"
+                           "  subcase: branch\n"
+                           "  info: index: 7\n"
+                           "1..1\n"
+                           "TOYTEST SUMMARY passed=0 failed=1\n");
 }
 
 // A repeated case name aborts the run before any body executes and reports the reserved code.
@@ -205,9 +217,8 @@ TEST_CASE("test/write_report/duplicate_name_aborts_before_the_first_case") {
   const int code = toy::test::writeReport(&captureWrite, &captured, head);
 
   REQUIRE(code == 2);
-  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
-                                                         "TOYTEST ERROR duplicate case name: sample/duplicate\n")
-          == 0);
+  REQUIRE_REPORT(captured, "TOYTEST 1\n"
+                           "TOYTEST ERROR duplicate case name: sample/duplicate\n");
 }
 
 // An empty registry is a run of no cases, not an error.
@@ -217,8 +228,32 @@ TEST_CASE("test/write_report/empty_registry_reports_an_empty_plan") {
   const int code = toy::test::writeReport(&captureWrite, &captured, nullptr);
 
   REQUIRE(code == 0);
-  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
-                                                         "1..0\n"
-                                                         "TOYTEST SUMMARY passed=0 failed=0\n")
-          == 0);
+  REQUIRE_REPORT(captured, "TOYTEST 1\n"
+                           "1..0\n"
+                           "TOYTEST SUMMARY passed=0 failed=0\n");
+}
+
+// A line filling the buffer gives up its last byte to the newline, because two lines run together are unreadable
+// while a truncated one is not.
+TEST_CASE("test::detail/report_writer/full_line_keeps_its_newline") {
+  constexpr std::size_t overlongLength = toy::test::detail::ReportWriter::c_lineCapacity * 2;
+
+  char overlong[overlongLength + 1] = {};
+
+  for (std::size_t index = 0; index < overlongLength; ++index)
+    overlong[index] = 'x';
+
+  CapturedReport                  captured;
+  toy::test::detail::ReportWriter writer{&captureWrite, &captured};
+
+  writer.addText(overlong);
+  writer.flush();
+
+  // The second line is what a missing terminator would swallow into the first.
+  writer.addText("next");
+  writer.flush();
+
+  REQUIRE(captured.length == toy::test::detail::ReportWriter::c_lineCapacity + 5);
+  REQUIRE(captured.text[toy::test::detail::ReportWriter::c_lineCapacity - 1] == '\n');
+  REQUIRE(captured.text[toy::test::detail::ReportWriter::c_lineCapacity - 2] == 'x');
 }

--- a/tests/runner/tests/report.test.cpp
+++ b/tests/runner/tests/report.test.cpp
@@ -1,0 +1,224 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   report.test.cpp
+  \brief  Unit tests for the TOYTEST report: entry per case, failure blocks, plan line, summary and exit code.
+*/
+
+#include <cstddef>
+
+#include <doctest/doctest.h>
+
+#include "report.hpp"
+
+namespace {
+
+constexpr std::size_t c_captureCapacity = 1024;
+
+// The report arrives here as raw bytes and is terminated, so a case can compare it against a literal in one call.
+struct CapturedReport final {
+  char        text[c_captureCapacity] = {};
+  std::size_t length                  = 0;
+};
+
+// The capture lives in the case that reads it and arrives through the writer data, so no state outlives a case.
+void captureWrite(const char * text, std::size_t length, void * writerData) noexcept {
+  CapturedReport & captured = *static_cast<CapturedReport *>(writerData);
+
+  for (std::size_t index = 0; index < length && captured.length + 1 < c_captureCapacity; ++index) {
+    captured.text[captured.length] = text[index];
+    ++captured.length;
+  }
+}
+
+// Bodies use the internal macro names, because the short ones belong to doctest inside this binary.
+void bodyPasses(toy::test::Context & toyTestContext) {
+  TOY_TEST_CHECK(1 == 1);
+}
+
+// Recording straight through the context is what keeps the file and line in the expected report fixed; a macro would
+// paste this file's own path and a line number that any edit above shifts.
+void bodyFailsTwice(toy::test::Context & context) {
+  static_cast<void>(context.record(false, "1 == 2", "first.cpp", 11));
+  static_cast<void>(context.record(false, "2 == 3", "second.cpp", 22));
+}
+
+void bodyRunsThreeSubcases(toy::test::Context & toyTestContext) {
+  TOY_TEST_SUBCASE("first") {
+    TOY_TEST_CHECK(1 == 1);
+  }
+  TOY_TEST_SUBCASE("second") {
+    TOY_TEST_CHECK(1 == 1);
+  }
+  TOY_TEST_SUBCASE("third") {
+    TOY_TEST_CHECK(1 == 1);
+  }
+}
+
+void bodyNestsSubcases(toy::test::Context & toyTestContext) {
+  TOY_TEST_SUBCASE("outer") {
+    TOY_TEST_SUBCASE("inner") {
+      TOY_TEST_CHECK(1 == 1);
+    }
+  }
+}
+
+void bodyFailsInsideSubcase(toy::test::Context & toyTestContext) {
+  TOY_TEST_SUBCASE("branch") {
+    TOY_TEST_INFO("index", 7);
+    static_cast<void>(toyTestContext.record(false, "values[index] == 0", "info.cpp", 33));
+  }
+}
+
+} // namespace
+
+// A run without a failure prints one entry per case, the plan line, the summary, and reports success.
+TEST_CASE("test/write_report/passing_run_prints_an_entry_per_case") {
+  toy::test::CaseRegistrar * head = nullptr;
+
+  toy::test::CaseRegistrar second{head, "sample/b/second", "b.cpp", 2, &bodyPasses};
+  toy::test::CaseRegistrar first{head, "sample/a/first", "a.cpp", 1, &bodyPasses};
+
+  CapturedReport captured;
+
+  const int code = toy::test::writeReport(&captureWrite, &captured, head);
+
+  REQUIRE(code == 0);
+  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
+                                                         "ok 1 - sample/a/first\n"
+                                                         "ok 2 - sample/b/second\n"
+                                                         "1..2\n"
+                                                         "TOYTEST SUMMARY passed=2 failed=0\n")
+          == 0);
+}
+
+// Two failures in one case share a single header and each print their own location block.
+TEST_CASE("test/write_report/failures_share_one_case_header") {
+  toy::test::CaseRegistrar * head = nullptr;
+
+  toy::test::CaseRegistrar only{head, "sample/fails", "a.cpp", 1, &bodyFailsTwice};
+
+  CapturedReport captured;
+
+  const int code = toy::test::writeReport(&captureWrite, &captured, head);
+
+  REQUIRE(code == 1);
+  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
+                                                         "not ok 1 - sample/fails\n"
+                                                         "  file: first.cpp\n"
+                                                         "  line: 11\n"
+                                                         "  expr: 1 == 2\n"
+                                                         "  file: second.cpp\n"
+                                                         "  line: 22\n"
+                                                         "  expr: 2 == 3\n"
+                                                         "1..1\n"
+                                                         "TOYTEST SUMMARY passed=0 failed=2\n")
+          == 0);
+}
+
+// Three branches give three runs of the body, so the summary counts three passing assertions under one entry.
+TEST_CASE("test/write_report/subcases_run_once_each_under_one_entry") {
+  toy::test::CaseRegistrar * head = nullptr;
+
+  toy::test::CaseRegistrar only{head, "sample/subcases", "a.cpp", 1, &bodyRunsThreeSubcases};
+
+  CapturedReport captured;
+
+  const int code = toy::test::writeReport(&captureWrite, &captured, head);
+
+  REQUIRE(code == 0);
+  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
+                                                         "ok 1 - sample/subcases\n"
+                                                         "1..1\n"
+                                                         "TOYTEST SUMMARY passed=3 failed=0\n")
+          == 0);
+}
+
+// A nested subcase condemns its case even though no assertion failed, and the run reports failure.
+TEST_CASE("test/write_report/nested_subcase_condemns_the_case") {
+  toy::test::CaseRegistrar * head = nullptr;
+
+  toy::test::CaseRegistrar only{head, "sample/nested", "a.cpp", 1, &bodyNestsSubcases};
+
+  CapturedReport captured;
+
+  const int code = toy::test::writeReport(&captureWrite, &captured, head);
+
+  REQUIRE(code == 1);
+  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
+                                                         "not ok 1 - sample/nested\n"
+                                                         "  error: nested subcase\n"
+                                                         "1..1\n"
+                                                         "TOYTEST SUMMARY passed=0 failed=0\n")
+          == 0);
+}
+
+// The subcase and the info entries live at the moment of the failure, so both reach the block under it.
+TEST_CASE("test/write_report/failure_block_carries_subcase_and_info") {
+  toy::test::CaseRegistrar * head = nullptr;
+
+  toy::test::CaseRegistrar only{head, "sample/info", "a.cpp", 1, &bodyFailsInsideSubcase};
+
+  CapturedReport captured;
+
+  const int code = toy::test::writeReport(&captureWrite, &captured, head);
+
+  REQUIRE(code == 1);
+  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
+                                                         "not ok 1 - sample/info\n"
+                                                         "  file: info.cpp\n"
+                                                         "  line: 33\n"
+                                                         "  expr: values[index] == 0\n"
+                                                         "  subcase: branch\n"
+                                                         "  info: index: 7\n"
+                                                         "1..1\n"
+                                                         "TOYTEST SUMMARY passed=0 failed=1\n")
+          == 0);
+}
+
+// A repeated case name aborts the run before any body executes and reports the reserved code.
+TEST_CASE("test/write_report/duplicate_name_aborts_before_the_first_case") {
+  toy::test::CaseRegistrar * head = nullptr;
+
+  toy::test::CaseRegistrar first{head, "sample/duplicate", "a.cpp", 1, &bodyPasses};
+  toy::test::CaseRegistrar second{head, "sample/duplicate", "b.cpp", 2, &bodyPasses};
+
+  CapturedReport captured;
+
+  const int code = toy::test::writeReport(&captureWrite, &captured, head);
+
+  REQUIRE(code == 2);
+  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
+                                                         "TOYTEST ERROR duplicate case name: sample/duplicate\n")
+          == 0);
+}
+
+// An empty registry is a run of no cases, not an error.
+TEST_CASE("test/write_report/empty_registry_reports_an_empty_plan") {
+  CapturedReport captured;
+
+  const int code = toy::test::writeReport(&captureWrite, &captured, nullptr);
+
+  REQUIRE(code == 0);
+  REQUIRE(toy::test::detail::compareNames(captured.text, "TOYTEST 1\n"
+                                                         "1..0\n"
+                                                         "TOYTEST SUMMARY passed=0 failed=0\n")
+          == 0);
+}

--- a/tests/runner/toy_test.cpp
+++ b/tests/runner/toy_test.cpp
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   toy_test.cpp
+  \brief  Entry point of the built-in test runner.
+*/
+
+#include <cstddef>
+
+#include "report.hpp"
+
+namespace {
+
+// The report's writer seam carries caller data the platform sink has no use for.
+void writeToPlatform(const char * text, std::size_t length, [[maybe_unused]] void * writerData) noexcept {
+  ::toy::test::platformWrite(text, length);
+}
+
+} // namespace
+
+int main() {
+  const int code = ::toy::test::writeReport(&writeToPlatform, nullptr, ::toy::test::detail::caseListHead);
+
+  ::toy::test::platformExit(code);
+}

--- a/tests/runner/toy_test.hpp
+++ b/tests/runner/toy_test.hpp
@@ -55,6 +55,28 @@ namespace toy::test {
 */
 void runCase(Context & context, const char * name, case_body_type body) noexcept;
 
+/*!
+  \brief Writes raw bytes to the platform's diagnostic channel.
+
+  \param text    Bytes to write; not null-terminated.
+  \param length  Number of bytes.
+
+  \note Defined per platform in one sink translation unit chosen by the build; the runner never branches on the target
+        itself.
+*/
+void platformWrite(const char * text, std::size_t length) noexcept;
+
+/*!
+  \brief Ends the run with the given code.
+
+  \param code  \c 0 when every assertion passed, \c 1 on any failure or a nested subcase, \c 2 on a duplicate
+               case name.
+
+  \note On consoles there is no process to exit, so the sink stores the code where a debugger reads it and then parks
+        the CPU.
+*/
+[[noreturn]] void platformExit(int code) noexcept;
+
 namespace detail {
 
 /*!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nintendo Wii U support for the console sample, including launchable RPX package generation and console logging.
  * Added a built-in test runner with structured reports for pass/fail results, nested cases, failure details, and exit statuses.

* **Build Improvements**
  * Wii U pull-request artifacts now receive consistent package naming and upload support.
  * Improved 64-bit Windows builds configured with debug information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->