### PR TITLE
feat(md): add Sega Mega Drive console sample and packaging support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
-# Documentation: https://releases.llvm.org/22.1.0/tools/clang/docs/ClangFormatStyleOptions.html
+# Documentation: https://releases.llvm.org/23.1.0/tools/clang/docs/ClangFormatStyleOptions.html
+# Release Notes: https://releases.llvm.org/23.1.0/tools/clang/docs/ReleaseNotes.html#clang-format
 ---
 # No Language key: this section is the default for every language, so one style covers
 # C++ (.cpp/.hpp/.inl) and Objective-C++ (.mm/.m). A `Language: Cpp`-only section makes
@@ -12,6 +13,7 @@ AlignConsecutiveAssignments:
   AcrossEmptyLines: false
   AcrossComments: true
   AlignCompound: true
+  EnumAssignments: true
   PadOperators: true
 AlignConsecutiveBitFields:
   Enabled: true
@@ -64,10 +66,9 @@ AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: Empty
 AllowShortLoopsOnASingleLine: false
 AllowShortNamespacesOnASingleLine: false
+AllowShortRecordOnASingleLine: EmptyAndAttached
 AlwaysBreakBeforeMultilineStrings: false
-BinPackArguments: true
 BinPackLongBracedList: true
-BinPackParameters: BinPack
 BitFieldColonSpacing: Both
 BracedInitializerIndentWidth: 2
 BreakAdjacentStringLiterals: true
@@ -89,10 +90,13 @@ BreakBeforeCloseBracketLoop: true
 BreakBeforeCloseBracketSwitch: true
 BreakBeforeConceptDeclarations: Always
 BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeReturnType: None
 BreakBeforeTemplateCloser: true
 BreakBeforeTernaryOperators: true
-BreakBinaryOperations: Never
+BreakBinaryOperations:
+  Default: Never
 BreakConstructorInitializers: BeforeComma
+BreakFunctionDeclarationParameters: false
 BreakFunctionDefinitionParameters: false
 BreakInheritanceList: BeforeComma
 BreakStringLiterals: false
@@ -150,10 +154,15 @@ NumericLiteralCase:
 ObjCBinPackProtocolList: Always
 ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: false
+ObjCSpaceAfterMethodDeclarationPrefix: true
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true
 PPIndentWidth: 2
+PackArguments:
+  BinPack: BinPack
 PackConstructorInitializers: BinPack
+PackParameters:
+  BinPack: BinPack
 PenaltyBreakAssignment: 19937
 PenaltyBreakBeforeFirstCallParameter: 19937
 PenaltyBreakBeforeMemberAccess: 19937

--- a/.github/workflows/build_cmake.yaml
+++ b/.github/workflows/build_cmake.yaml
@@ -82,6 +82,7 @@ jobs:
             container: ghcr.io/toymaninteractive/toygine2.md.toolchain:latest
             run_test: "false"
             cmake_preset: md-release
+            artifact_id: md
 
           - name: Nintendo GBA
             os: ubuntu-26.04

--- a/.github/workflows/check_code_style.yaml
+++ b/.github/workflows/check_code_style.yaml
@@ -27,9 +27,9 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 22
-          sudo apt install -y clang-format-22
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-22 220
+          sudo ./llvm.sh 23
+          sudo apt install -y clang-format-23
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-23 230
 
       - name: Get changed files
         env:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -383,7 +383,6 @@
                 "platform-md",
                 "with-benchmarks",
                 "with-samples",
-                "with-tests",
                 "base"
             ]
         },
@@ -395,7 +394,6 @@
                 "type-release",
                 "platform-md",
                 "with-benchmarks",
-                "with-tests",
                 "base"
             ]
         },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1109,6 +1109,22 @@
             ]
         },
         {
+            "name": "md-release",
+            "configurePreset": "md-release",
+            "inherits": [
+                "type-release",
+                "base"
+            ]
+        },
+        {
+            "name": "md-shipping",
+            "configurePreset": "md-shipping",
+            "inherits": [
+                "type-shipping",
+                "base"
+            ]
+        },
+        {
             "name": "gba-release",
             "configurePreset": "gba-release",
             "inherits": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -394,6 +394,7 @@
                 "type-release",
                 "platform-md",
                 "with-benchmarks",
+                "with-samples",
                 "base"
             ]
         },

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -28,7 +28,7 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
   # MSVC Compiler Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/compiler-options-listed-by-category?view=msvc-170#optimization
-  # last option is /Gy
+  # last option is /jumptablerdata
 
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
@@ -63,11 +63,11 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
       string(APPEND CMAKE_C_FLAGS   " /arch:SSE2 /fpcvt:IA")
       string(APPEND CMAKE_CXX_FLAGS " /arch:SSE2 /fpcvt:IA")
 
-      string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          " /favor:blend /Gv /homeparams")
-      string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        " /favor:blend /Gv /homeparams")
+      string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO          " /favor:blend /Gv /homeparams /jumptablerdata")
+      string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO        " /favor:blend /Gv /homeparams /jumptablerdata")
 
-      string(APPEND CMAKE_C_FLAGS_RELEASE                 " /favor:blend /Gv")
-      string(APPEND CMAKE_CXX_FLAGS_RELEASE               " /favor:blend /Gv")
+      string(APPEND CMAKE_C_FLAGS_RELEASE                 " /favor:blend /Gv             /jumptablerdata")
+      string(APPEND CMAKE_CXX_FLAGS_RELEASE               " /favor:blend /Gv             /jumptablerdata")
 
       string(APPEND CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "")
 

--- a/samples/console/CMakeLists.txt
+++ b/samples/console/CMakeLists.txt
@@ -18,11 +18,19 @@
 # DEALINGS IN THE SOFTWARE.
 #-----------------------------------------------------------------------------------------------------------------------
 
-add_executable(console_sample_app console_sample_app.cpp)
+if (TOYGINE_TARGET_PLATFORM STREQUAL "Sega MD")
+  add_cartridge_executable(console_sample_app console_sample_app.cpp)
+else()
+  add_executable(console_sample_app console_sample_app.cpp)
+endif()
 
 target_link_libraries(console_sample_app PRIVATE toygine)
 
-if (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo GBA")
+if (TOYGINE_TARGET_PLATFORM STREQUAL "Sega MD")
+
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/console_sample_app.bin" DESTINATION bin COMPONENT samples)
+
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo GBA")
 
   gba_create_rom(console_sample_app)
 

--- a/samples/console/console_sample_app.cpp
+++ b/samples/console/console_sample_app.cpp
@@ -22,6 +22,22 @@
   \brief
 */
 
+#ifdef __MEGA_DRIVE__
+
+#include <clownmdsdk.h>
+
+void _EntryPoint() {
+  // Do initialisation here.
+
+  ClownMDSDK::MainCPU::Debug::PrintLine("Hello world from Console sample app");
+
+  for (;;) {
+    // Run main-loop logic here.
+  }
+}
+
+#endif // __MEGA_DRIVE__
+
 #ifdef __GBA__
 
 #include <cstdio>
@@ -221,8 +237,8 @@ int main(int argc, char ** argv) {
 
 #endif // __WIIU__
 
-#if !defined(__GBA__) && !defined(__NDS__) && !defined(__3DS__) && !defined(__SWITCH__) && !defined(__gamecube__)      \
-  && !defined(__wii__) && !defined(__WIIU__)
+#if !defined(__MEGA_DRIVE__) && !defined(__GBA__) && !defined(__NDS__) && !defined(__3DS__) && !defined(__SWITCH__)    \
+  && !defined(__gamecube__) && !defined(__wii__) && !defined(__WIIU__)
 
 #include <iostream>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,34 @@ endif ()
 set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
 #-----------------------------------------------------------------------------------------------------------------------
 
+#-----------------------------------------------------------------------------------------------------------------------
+# Test translation units
+#-----------------------------------------------------------------------------------------------------------------------
+
+# The runner's own translation units: its entry point and the platform sink. Task 8 replaces the desktop sink named
+# here with the one the target platform provides.
+set(TOYGINE_RUNNER_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/runner/toy_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/runner/sink_desktop.cpp)
+
+# Tests of engine modules. They build under both runners, which is what makes a semantic drift between the two
+# visible as a failing build or a differing verdict.
+file(GLOB_RECURSE TOYGINE_MODULE_TESTS_SRC CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*.test.cpp")
+list(FILTER TOYGINE_MODULE_TESTS_SRC EXCLUDE REGEX "/runner/")
+
+# Tests of the runner itself. They are written against doctest and inspect the runner's internals, so they build
+# under doctest only.
+file(GLOB TOYGINE_RUNNER_TESTS_SRC CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/runner/tests/*.test.cpp")
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Tests built with the runner written for consoles
+#-----------------------------------------------------------------------------------------------------------------------
+
+add_executable(${TOYGINE_LIBRARY_NAME}-units-builtin ${TOYGINE_RUNNER_SRC} ${TOYGINE_MODULE_TESTS_SRC})
+target_include_directories(${TOYGINE_LIBRARY_NAME}-units-builtin
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runner ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_link_libraries(${TOYGINE_LIBRARY_NAME}-units-builtin PRIVATE ${TOYGINE_LIBRARY_NAME})
+
 if (TOYGINE_TARGET_PLATFORM_SUPPORT_CTEST)
   include(FetchContent)
   include(CTest)
@@ -54,29 +82,22 @@ if (TOYGINE_TARGET_PLATFORM_SUPPORT_CTEST)
 
   list(APPEND CMAKE_MODULE_PATH ${doctest_SOURCE_DIR}/scripts/cmake)
 
-  # Only files named *.test.cpp are test translation units. The runner's own implementation, its sinks and the
-  # self-test binaries carry their own main() and belong to other targets, so the pattern keeps them out.
-  file(GLOB_RECURSE TESTS_SRC CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*.test.cpp")
-
-  list(APPEND TESTS_SRC tests.cpp)
-
   include(doctest)
 
-  add_executable(${TOYGINE_LIBRARY_NAME}-units ${TESTS_SRC})
-  target_compile_definitions(${TOYGINE_LIBRARY_NAME}-units PRIVATE DOCTEST_CONFIG_SUPER_FAST_ASSERTS TOYGINE_TESTS_USE_DOCTEST)
+  add_executable(${TOYGINE_LIBRARY_NAME}-units
+      ${TOYGINE_MODULE_TESTS_SRC}
+      ${TOYGINE_RUNNER_TESTS_SRC}
+      tests.cpp)
+  target_compile_definitions(${TOYGINE_LIBRARY_NAME}-units PRIVATE DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+                                                                  TOYGINE_TESTS_USE_DOCTEST)
 
   target_include_directories(${TOYGINE_LIBRARY_NAME}-units PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
   target_include_directories(${TOYGINE_LIBRARY_NAME}-units PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runner)
   target_link_libraries(${TOYGINE_LIBRARY_NAME}-units PRIVATE doctest::doctest ${TOYGINE_LIBRARY_NAME})
   doctest_discover_tests(${TOYGINE_LIBRARY_NAME}-units)
 
-  # The runner's own translation units: its entry point and the platform sink. Nothing links them until task 7 builds
-  # the tests with them, so compiling them as objects is what keeps a broken entry point from surviving until then.
-  # Task 8 moves the sink's platform choice out of this desktop-only guard.
-  add_library(${TOYGINE_LIBRARY_NAME}-runner OBJECT
-      ${CMAKE_CURRENT_SOURCE_DIR}/runner/toy_test.cpp
-      ${CMAKE_CURRENT_SOURCE_DIR}/runner/sink_desktop.cpp)
-  target_include_directories(${TOYGINE_LIBRARY_NAME}-runner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runner)
+  # Exit code 0 is the whole contract: every module test must reach the same verdict under both runners.
+  add_test(NAME units-builtin COMMAND ${TOYGINE_LIBRARY_NAME}-units-builtin)
 
   # CodeCoverage aborts on anything but a gcov-compatible toolchain, so keep the option a no-op elsewhere (MSVC)
   set(TOYGINE_COMPILER_SUPPORT_COVERAGE OFF)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,20 +49,17 @@ set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
 # Test translation units
 #-----------------------------------------------------------------------------------------------------------------------
 
-# The runner's own translation units: its entry point and the platform sink. Task 8 replaces the desktop sink named
-# here with the one the target platform provides.
+# The runner's own translation units: its entry point and the platform sink.
 set(TOYGINE_RUNNER_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/runner/toy_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/runner/sink_desktop.cpp)
 
-# Tests of engine modules. They build under both runners, which is what makes a semantic drift between the two
-# visible as a failing build or a differing verdict.
-file(GLOB_RECURSE TOYGINE_MODULE_TESTS_SRC CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*.test.cpp")
-list(FILTER TOYGINE_MODULE_TESTS_SRC EXCLUDE REGEX "/runner/")
+# Tests of engine modules. Both runners build them, so a drift between the two splits the verdict or fails the build.
+file(GLOB_RECURSE TOYGINE_MODULE_TESTS_SRC CONFIGURE_DEPENDS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/*.test.cpp")
+list(FILTER TOYGINE_MODULE_TESTS_SRC EXCLUDE REGEX "^runner/")
 
-# Tests of the runner itself. They are written against doctest and inspect the runner's internals, so they build
-# under doctest only.
-file(GLOB TOYGINE_RUNNER_TESTS_SRC CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/runner/tests/*.test.cpp")
+# Tests of the runner itself. Written against doctest and inspecting its internals, so only doctest builds them.
+file(GLOB TOYGINE_RUNNER_TESTS_SRC CONFIGURE_DEPENDS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/runner/tests/*.test.cpp")
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Tests built with the runner written for consoles
@@ -128,7 +125,7 @@ if (TOYGINE_TARGET_PLATFORM_SUPPORT_CTEST)
     setup_target_for_coverage_lcov(NAME unit_tests_coverage EXECUTABLE ctest
                                    # tests run serially: parallel cases of one binary race over the same .gcda files
                                    EXECUTABLE_ARGS --output-on-failure --no-tests=error
-                                   DEPENDENCIES ${TOYGINE_LIBRARY_NAME}-units
+                                   DEPENDENCIES ${TOYGINE_LIBRARY_NAME}-units ${TOYGINE_LIBRARY_NAME}-units-builtin
                                    LCOV_ARGS "--ignore-errors" "inconsistent")
 
   endif ()

--- a/tests/core/bitwise_enum.test.cpp
+++ b/tests/core/bitwise_enum.test.cpp
@@ -22,9 +22,8 @@
   \brief  Unit tests for \ref toy::EnableBitwiseOperators and scoped-enum bitwise operators.
 */
 
-#include <doctest/doctest.h>
-
 #include "core.hpp"
+#include "toy_test.hpp"
 
 namespace toy {
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sega Mega Drive support for the console sample application, including a native entry point and generated binary output.
  * Added Mega Drive release and shipping package configurations.
* **Bug Fixes**
  * Mega Drive builds now produce, package, and upload their artifacts correctly.
* **Build Improvements**
  * Updated compiler tooling and formatting configuration.
  * Improved x64 Windows release build options.
* **Tests**
  * Reorganized test targets and added coverage for built-in test components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->