### PR TITLE
test: add platform-specific test runners

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -383,6 +383,7 @@
                 "platform-md",
                 "with-benchmarks",
                 "with-samples",
+                "with-tests",
                 "base"
             ]
         },
@@ -395,6 +396,7 @@
                 "platform-md",
                 "with-benchmarks",
                 "with-samples",
+                "with-tests",
                 "base"
             ]
         },

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -28,7 +28,7 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
 
   # MSVC Compiler Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/compiler-options-listed-by-category?view=msvc-170#optimization
-  # last option is /jumptablerdata
+  # last option is /RTC1
 
   # MSVC Linker Options
   # https://learn.microsoft.com/en-nz/cpp/build/reference/linker-options?view=msvc-170
@@ -36,8 +36,8 @@ if (TOYGINE_TARGET_PLATFORM STREQUAL "Windows Desktop")
     set(CMAKE_C_FLAGS                  "/EHsc /GA /GR- /GS /guard:cf")
     set(CMAKE_CXX_FLAGS                "/EHsc /GA /GR- /GS /guard:cf")
 
-    set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except  /Gd /GF- /GL- /Gw- /Gy-")
-    set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except  /Gd /GF- /GL- /Gw- /Gy-")
+    set(CMAKE_C_FLAGS_DEBUG            "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except  /Gd /GF- /GL- /Gw- /Gy- /RTC1")
+    set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Ob0 /Oi-     /Oy- /fp:strict /fp:except  /Gd /GF- /GL- /Gw- /Gy- /RTC1")
 
     set(CMAKE_C_FLAGS_RELWITHDEBINFO   "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except-     /GF  /GL  /Gw  /Gy")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Ob3 /Oi  /Ot /Oy- /fp:fast   /fp:except-     /GF  /GL  /Gw  /Gy")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,10 +33,11 @@ endif ()
 # CTest support
 #-----------------------------------------------------------------------------------------------------------------------
 
-set(TOYGINE_TARGET_PLATFORM_SUPPORT_CTEST OFF)
+set(TOYGINE_DESKTOP_PLATFORMS "Windows Desktop" "Linux Desktop" "macOS Desktop")
 
-set(TOYGINE_CTEST_SUPPORT_PLATFORMS "Windows Desktop" "Linux Desktop" "macOS Desktop")
-if (TOYGINE_TARGET_PLATFORM IN_LIST TOYGINE_CTEST_SUPPORT_PLATFORMS)
+# Whether the built binaries can be executed by CTest on the build host.
+set(TOYGINE_TARGET_PLATFORM_SUPPORT_CTEST OFF)
+if (TOYGINE_TARGET_PLATFORM IN_LIST TOYGINE_DESKTOP_PLATFORMS)
   set(TOYGINE_TARGET_PLATFORM_SUPPORT_CTEST ON)
 endif ()
 
@@ -49,10 +50,29 @@ set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
 # Test translation units
 #-----------------------------------------------------------------------------------------------------------------------
 
-# The runner's own translation units: its entry point and the platform sink.
-set(TOYGINE_RUNNER_SRC
-    ${CMAKE_CURRENT_SOURCE_DIR}/runner/toy_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/runner/sink_desktop.cpp)
+# The runner's platform layer: output, exit, and the entry point. A file, not a macro, so the runner itself carries
+# no target branches.
+if (TOYGINE_TARGET_PLATFORM IN_LIST TOYGINE_DESKTOP_PLATFORMS)
+  set(TOYGINE_RUNNER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/runner/platforms/desktop.cpp)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Sega MD")
+  set(TOYGINE_RUNNER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/runner/platforms/md.cpp)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo GBA")
+  set(TOYGINE_RUNNER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/runner/platforms/gba.cpp)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo DS")
+  set(TOYGINE_RUNNER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/runner/platforms/nds.cpp)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo 3DS")
+  set(TOYGINE_RUNNER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/runner/platforms/3ds.cpp)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo Switch")
+  set(TOYGINE_RUNNER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/runner/platforms/switch.cpp)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo GameCube")
+  set(TOYGINE_RUNNER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/runner/platforms/gamecube.cpp)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo Wii")
+  set(TOYGINE_RUNNER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/runner/platforms/wii.cpp)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo Wii U")
+  set(TOYGINE_RUNNER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/runner/platforms/wii_u.cpp)
+else ()
+  message(FATAL_ERROR "Unsupported platform: ${TOYGINE_TARGET_PLATFORM}")
+endif ()
 
 # Tests of engine modules. Both runners build them, so a drift between the two splits the verdict or fails the build.
 file(GLOB_RECURSE TOYGINE_MODULE_TESTS_SRC CONFIGURE_DEPENDS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/*.test.cpp")
@@ -65,10 +85,33 @@ file(GLOB TOYGINE_RUNNER_TESTS_SRC CONFIGURE_DEPENDS RELATIVE "${CMAKE_CURRENT_S
 # Tests built with the runner written for consoles
 #-----------------------------------------------------------------------------------------------------------------------
 
-add_executable(${TOYGINE_LIBRARY_NAME}-units-builtin ${TOYGINE_RUNNER_SRC} ${TOYGINE_MODULE_TESTS_SRC})
+# Sega MD has no plain executable: the cartridge linker script and its startup stub are what give the binary an entry.
+if (TOYGINE_TARGET_PLATFORM STREQUAL "Sega MD")
+  add_cartridge_executable(${TOYGINE_LIBRARY_NAME}-units-builtin ${TOYGINE_RUNNER_SRC} ${TOYGINE_MODULE_TESTS_SRC})
+else ()
+  add_executable(${TOYGINE_LIBRARY_NAME}-units-builtin ${TOYGINE_RUNNER_SRC} ${TOYGINE_MODULE_TESTS_SRC})
+endif ()
+
 target_include_directories(${TOYGINE_LIBRARY_NAME}-units-builtin
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runner ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 target_link_libraries(${TOYGINE_LIBRARY_NAME}-units-builtin PRIVATE ${TOYGINE_LIBRARY_NAME})
+
+# The ELF alone is not something the console can load; the ROM is what the next spec hands to an emulator.
+if (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo GBA")
+  gba_create_rom(${TOYGINE_LIBRARY_NAME}-units-builtin)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo DS")
+  nds_create_rom(${TOYGINE_LIBRARY_NAME}-units-builtin)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo 3DS")
+  ctr_create_3dsx(${TOYGINE_LIBRARY_NAME}-units-builtin)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo Switch")
+  nx_create_nro(${TOYGINE_LIBRARY_NAME}-units-builtin)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo GameCube")
+  ogc_create_dol(${TOYGINE_LIBRARY_NAME}-units-builtin)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo Wii")
+  ogc_create_dol(${TOYGINE_LIBRARY_NAME}-units-builtin)
+elseif (TOYGINE_TARGET_PLATFORM STREQUAL "Nintendo Wii U")
+  wut_create_rpx(${TOYGINE_LIBRARY_NAME}-units-builtin)
+endif ()
 
 if (TOYGINE_TARGET_PLATFORM_SUPPORT_CTEST)
   include(FetchContent)
@@ -84,7 +127,7 @@ if (TOYGINE_TARGET_PLATFORM_SUPPORT_CTEST)
   add_executable(${TOYGINE_LIBRARY_NAME}-units
       ${TOYGINE_MODULE_TESTS_SRC}
       ${TOYGINE_RUNNER_TESTS_SRC}
-      tests.cpp)
+      ctest_main.cpp)
   target_compile_definitions(${TOYGINE_LIBRARY_NAME}-units PRIVATE DOCTEST_CONFIG_SUPER_FAST_ASSERTS
                                                                   TOYGINE_TESTS_USE_DOCTEST)
 

--- a/tests/ctest_main.cpp
+++ b/tests/ctest_main.cpp
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   ctest_main.cpp
+  \brief  Entry point of the doctest build: applies the command line and runs the registered cases.
+*/
+
+#define DOCTEST_CONFIG_IMPLEMENT
+
+#include <doctest/doctest.h>
+
+#include "core.hpp"
+
+int main(int argc, char ** argv) noexcept {
+  doctest::Context context;
+
+  context.applyCommandLine(argc, argv);
+
+  return context.run(); // run doctest
+}

--- a/tests/runner/platforms/3ds.cpp
+++ b/tests/runner/platforms/3ds.cpp
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   3ds.cpp
+  \brief  Platform layer for Nintendo 3DS: console output and the entry point.
+*/
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdio>
+
+// clang-format off
+#include <3ds.h>
+// clang-format on
+
+#include "report.hpp"
+
+namespace {
+
+// Columns of the console consoleInit() sets up on the top screen: its 400 pixels over the 8-pixel tiles it draws with.
+constexpr std::size_t c_consoleWidth = 50;
+
+// The report's writer seam carries caller data stdout has no use for. A line wider than one row is cut to it:
+// printing the tail would cost further rows and push the summary off the top of the screen.
+void writeToStdout(const char * text, std::size_t length, [[maybe_unused]] void * writerData) noexcept {
+  const auto count = std::min(length, c_consoleWidth);
+
+  printf("%.*s", static_cast<int>(count), text);
+}
+
+} // namespace
+
+int main() {
+  gfxInitDefault();
+
+  consoleInit(GFX_TOP, nullptr);
+
+  const int code = ::toy::test::writeReport(&writeToStdout, nullptr, ::toy::test::detail::caseListHead);
+
+  while (aptMainLoop()) {
+    gfxFlushBuffers();
+    gfxSwapBuffers();
+
+    gspWaitForVBlank();
+  }
+
+  gfxExit();
+
+  return code;
+}

--- a/tests/runner/platforms/desktop.cpp
+++ b/tests/runner/platforms/desktop.cpp
@@ -18,20 +18,29 @@
 // DEALINGS IN THE SOFTWARE.
 //
 /*!
-  \file   tests.cpp
-  \brief  Test runner entry point: doctest \c main, assertion hooks, and optional GBA console routing.
+  \file   desktop.cpp
+  \brief  Platform layer for Windows, Linux and macOS: standard output, the process exit code, and the entry point.
 */
 
-#define DOCTEST_CONFIG_IMPLEMENT
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 
-#include <doctest/doctest.h>
+#include "report.hpp"
 
-#include "core.hpp"
+namespace {
 
-int main(int argc, char ** argv) noexcept {
-  doctest::Context context;
+// The report's writer seam carries caller data stdout has no use for.
+void writeToStdout(const char * text, std::size_t length, [[maybe_unused]] void * writerData) noexcept {
+  std::fwrite(text, 1, length, stdout);
+}
 
-  context.applyCommandLine(argc, argv);
+} // namespace
 
-  return context.run(); // run doctest
+int main() {
+  const int code = ::toy::test::writeReport(&writeToStdout, nullptr, ::toy::test::detail::caseListHead);
+
+  std::fflush(stdout);
+
+  std::exit(code);
 }

--- a/tests/runner/platforms/gamecube.cpp
+++ b/tests/runner/platforms/gamecube.cpp
@@ -1,0 +1,77 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   gamecube.cpp
+  \brief  Platform layer for Nintendo GameCube: console output and the entry point.
+*/
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdio>
+
+#include <gccore.h>
+
+#include "report.hpp"
+
+namespace {
+
+// Columns one row of the console holds. Unknown until the video mode is picked, so main() fills it in before the
+// first report line is written; the value here only keeps the writer safe if that ever stops being true.
+std::size_t consoleWidth = 0;
+
+// The report's writer seam carries caller data stdout has no use for. A line wider than one row is cut to it:
+// printing the tail would cost further rows and push the summary off the top of the screen.
+void writeToStdout(const char * text, std::size_t length, [[maybe_unused]] void * writerData) noexcept {
+  const auto count = std::min(length, consoleWidth);
+
+  printf("%.*s", static_cast<int>(count), text);
+}
+
+} // namespace
+
+int main() {
+  VIDEO_Init();
+
+  auto * rmode = VIDEO_GetPreferredMode(nullptr);
+
+  auto * framebuffer = MEM_K0_TO_K1(SYS_AllocateFramebuffer(rmode));
+  console_init(framebuffer, 20, 20, rmode->fbWidth, rmode->xfbHeight, rmode->fbWidth * VI_DISPLAY_PIX_SZ);
+
+  VIDEO_Configure(rmode);
+  VIDEO_SetNextFramebuffer(framebuffer);
+  VIDEO_SetBlack(FALSE);
+  VIDEO_Flush();
+  VIDEO_WaitVSync();
+  if (rmode->viTVMode & VI_NON_INTERLACE)
+    VIDEO_WaitVSync();
+
+  int columns = 0;
+  int rows    = 0;
+  CON_GetMetrics(&columns, &rows);
+
+  consoleWidth = static_cast<std::size_t>(columns);
+
+  const int code = ::toy::test::writeReport(&writeToStdout, nullptr, ::toy::test::detail::caseListHead);
+
+  while (SYS_MainLoop())
+    VIDEO_WaitVSync();
+
+  return code;
+}

--- a/tests/runner/platforms/gba.cpp
+++ b/tests/runner/platforms/gba.cpp
@@ -18,25 +18,45 @@
 // DEALINGS IN THE SOFTWARE.
 //
 /*!
-  \file   sink_desktop.cpp
-  \brief  Output and exit for Windows, Linux and macOS: standard output and the process exit code.
+  \file   gba.cpp
+  \brief  Platform layer for Nintendo GBA: console output and the entry point.
 */
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdio>
-#include <cstdlib>
 
-#include "toy_test.hpp"
+#include <gba_console.h>
+#include <gba_interrupt.h>
+#include <gba_systemcalls.h>
 
-namespace toy::test {
+#include "report.hpp"
 
-void platformWrite(const char * text, std::size_t length) noexcept {
-  std::fwrite(text, 1, length, stdout);
+namespace {
+
+// Columns of the console consoleDemoInit() sets up: the 240-pixel screen over the 8-pixel tiles it draws with.
+constexpr std::size_t c_consoleWidth = 30;
+
+// The report's writer seam carries caller data stdout has no use for. A line wider than one row is cut to it:
+// printing the tail would cost further rows and push the summary off the top of the screen.
+void writeToStdout(const char * text, std::size_t length, [[maybe_unused]] void * writerData) noexcept {
+  const auto count = std::min(length, c_consoleWidth);
+
+  printf("%.*s", static_cast<int>(count), text);
 }
 
-void platformExit(int code) noexcept {
-  std::fflush(stdout);
+} // namespace
 
-  std::exit(code);
+int main() {
+  irqInit();
+  irqEnable(IRQ_VBLANK);
+
+  consoleDemoInit();
+
+  const int code = ::toy::test::writeReport(&writeToStdout, nullptr, ::toy::test::detail::caseListHead);
+
+  while (1)
+    VBlankIntrWait();
+
+  return 0;
 }
-
-} // namespace toy::test

--- a/tests/runner/platforms/md.cpp
+++ b/tests/runner/platforms/md.cpp
@@ -18,25 +18,33 @@
 // DEALINGS IN THE SOFTWARE.
 //
 /*!
-  \file   toy_test.cpp
-  \brief  Entry point of the built-in test runner.
+  \file   md.cpp
+  \brief  Platform layer for Sega Mega Drive: debug-port output and the entry point.
 */
 
 #include <cstddef>
+
+#include <clownmdsdk.h>
 
 #include "report.hpp"
 
 namespace {
 
-// The report's writer seam carries caller data the platform sink has no use for.
-void writeToPlatform(const char * text, std::size_t length, [[maybe_unused]] void * writerData) noexcept {
-  ::toy::test::platformWrite(text, length);
+// The report's writer seam carries caller data the debug port has no use for. Bytes go one at a time because the
+// text carries no terminator, and nothing is cut to a row: this port is a stream, not a screen.
+void writeToDebugPort(const char * text, std::size_t length, [[maybe_unused]] void * writerData) noexcept {
+  // The port ends a line on a null byte, which is what Debug::PrintNewline() sends. A newline reaching it as-is
+  // would print as one more character, running the whole report into a single line.
+  for (std::size_t index = 0; index < length; ++index)
+    ClownMDSDK::MainCPU::Debug::Print(text[index] == '\n' ? '\0' : text[index]);
 }
 
 } // namespace
 
-int main() {
-  const int code = ::toy::test::writeReport(&writeToPlatform, nullptr, ::toy::test::detail::caseListHead);
+// The cartridge linker script enters here: there is no C runtime on this target to call main() for us.
+void _EntryPoint() {
+  static_cast<void>(::toy::test::writeReport(&writeToDebugPort, nullptr, ::toy::test::detail::caseListHead));
 
-  ::toy::test::platformExit(code);
+  // Nothing to return to and no process to leave. The summary line carries the verdict and has already been printed.
+  for (;;) {}
 }

--- a/tests/runner/platforms/nds.cpp
+++ b/tests/runner/platforms/nds.cpp
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   nds.cpp
+  \brief  Platform layer for Nintendo DS: console output and the entry point.
+*/
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdio>
+
+#include <nds.h>
+
+#include "report.hpp"
+
+namespace {
+
+// Columns of the console consoleDemoInit() sets up: the 256-pixel screen over the 8-pixel tiles it draws with.
+constexpr std::size_t c_consoleWidth = 32;
+
+// The report's writer seam carries caller data stdout has no use for. A line wider than one row is cut to it:
+// printing the tail would cost further rows and push the summary off the top of the screen.
+void writeToStdout(const char * text, std::size_t length, [[maybe_unused]] void * writerData) noexcept {
+  const auto count = std::min(length, c_consoleWidth);
+
+  printf("%.*s", static_cast<int>(count), text);
+}
+
+} // namespace
+
+int main() {
+  consoleDemoInit();
+
+  const int code = ::toy::test::writeReport(&writeToStdout, nullptr, ::toy::test::detail::caseListHead);
+
+  while (pmMainLoop())
+    swiWaitForVBlank();
+
+  return code;
+}

--- a/tests/runner/platforms/switch.cpp
+++ b/tests/runner/platforms/switch.cpp
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   switch.cpp
+  \brief  Platform layer for Nintendo Switch: console output and the entry point.
+*/
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdio>
+
+#include <switch.h>
+
+#include "report.hpp"
+
+namespace {
+
+// Columns one row of the console consoleInit() sets up holds. libnx reports the figure in PrintConsole::consoleWidth
+// but publishes no default, so it is fixed here.
+constexpr std::size_t c_consoleWidth = 80;
+
+// The report's writer seam carries caller data stdout has no use for. A line wider than one row is cut to it:
+// printing the tail would cost further rows and push the summary off the top of the screen.
+void writeToStdout(const char * text, std::size_t length, [[maybe_unused]] void * writerData) noexcept {
+  const auto count = std::min(length, c_consoleWidth);
+
+  printf("%.*s", static_cast<int>(count), text);
+}
+
+} // namespace
+
+int main() {
+  consoleInit(nullptr);
+
+  padConfigureInput(1, HidNpadStyleSet_NpadStandard);
+
+  PadState pad;
+  padInitializeDefault(&pad);
+
+  const int code = ::toy::test::writeReport(&writeToStdout, nullptr, ::toy::test::detail::caseListHead);
+
+  // The report holds the screen until Plus is pressed: the applet closes on its own otherwise, taking the last
+  // lines with it.
+  while (appletMainLoop()) {
+    padUpdate(&pad);
+
+    if ((padGetButtonsDown(&pad) & HidNpadButton_Plus) != 0)
+      break;
+
+    consoleUpdate(nullptr);
+  }
+
+  consoleExit(nullptr);
+
+  return code;
+}

--- a/tests/runner/platforms/wii.cpp
+++ b/tests/runner/platforms/wii.cpp
@@ -1,0 +1,77 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   wii.cpp
+  \brief  Platform layer for Nintendo Wii: console output and the entry point.
+*/
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdio>
+
+#include <gccore.h>
+
+#include "report.hpp"
+
+namespace {
+
+// Columns one row of the console holds. Unknown until the video mode is picked, so main() fills it in before the
+// first report line is written; the value here only keeps the writer safe if that ever stops being true.
+std::size_t consoleWidth = 0;
+
+// The report's writer seam carries caller data stdout has no use for. A line wider than one row is cut to it:
+// printing the tail would cost further rows and push the summary off the top of the screen.
+void writeToStdout(const char * text, std::size_t length, [[maybe_unused]] void * writerData) noexcept {
+  const auto count = std::min(length, consoleWidth);
+
+  printf("%.*s", static_cast<int>(count), text);
+}
+
+} // namespace
+
+int main() {
+  VIDEO_Init();
+
+  auto * rmode = VIDEO_GetPreferredMode(nullptr);
+
+  auto * framebuffer = MEM_K0_TO_K1(SYS_AllocateFramebuffer(rmode));
+  console_init(framebuffer, 20, 20, rmode->fbWidth, rmode->xfbHeight, rmode->fbWidth * VI_DISPLAY_PIX_SZ);
+
+  VIDEO_Configure(rmode);
+  VIDEO_SetNextFramebuffer(framebuffer);
+  VIDEO_SetBlack(false);
+  VIDEO_Flush();
+  VIDEO_WaitVSync();
+  if (rmode->viTVMode & VI_NON_INTERLACE)
+    VIDEO_WaitVSync();
+
+  int columns = 0;
+  int rows    = 0;
+  CON_GetMetrics(&columns, &rows);
+
+  consoleWidth = static_cast<std::size_t>(columns);
+
+  const int code = ::toy::test::writeReport(&writeToStdout, nullptr, ::toy::test::detail::caseListHead);
+
+  while (SYS_MainLoop())
+    VIDEO_WaitVSync();
+
+  return code;
+}

--- a/tests/runner/platforms/wii_u.cpp
+++ b/tests/runner/platforms/wii_u.cpp
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2026 Toyman Interactive
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and / or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/*!
+  \file   wii_u.cpp
+  \brief  Platform layer for Nintendo Wii U: console output and the entry point.
+*/
+
+#include <algorithm>
+#include <cstddef>
+
+#include <coreinit/thread.h>
+#include <coreinit/time.h>
+#include <whb/log.h>
+#include <whb/log_console.h>
+#include <whb/proc.h>
+
+#include "report.hpp"
+
+namespace {
+
+// Columns one row of the WHB log console holds. The WHB API reports no width, so the figure is fixed here.
+constexpr std::size_t c_consoleWidth = 80;
+
+// The report's writer seam carries caller data the log console has no use for. One call is one log entry, so the
+// trailing newline goes, and a line wider than the screen is cut to what one row holds.
+void writeToLog(const char * text, std::size_t length, [[maybe_unused]] void * writerData) noexcept {
+  const auto lineLength = (length != 0 && text[length - 1] == '\n') ? length - 1 : length;
+  const auto count      = std::min(lineLength, c_consoleWidth);
+
+  WHBLogPrintf("%.*s", static_cast<int>(count), text);
+}
+
+} // namespace
+
+int main() {
+  WHBProcInit();
+  WHBLogConsoleInit();
+
+  const int code = ::toy::test::writeReport(&writeToLog, nullptr, ::toy::test::detail::caseListHead);
+
+  while (WHBProcIsRunning()) {
+    WHBLogConsoleDraw();
+
+    OSSleepTicks(OSMillisecondsToTicks(100));
+  }
+
+  WHBLogConsoleFree();
+  WHBProcShutdown();
+
+  return code;
+}

--- a/tests/runner/toy_test.hpp
+++ b/tests/runner/toy_test.hpp
@@ -55,28 +55,6 @@ namespace toy::test {
 */
 void runCase(Context & context, const char * name, case_body_type body) noexcept;
 
-/*!
-  \brief Writes raw bytes to the platform's diagnostic channel.
-
-  \param text    Bytes to write; not null-terminated.
-  \param length  Number of bytes.
-
-  \note Defined per platform in one sink translation unit chosen by the build; the runner never branches on the target
-        itself.
-*/
-void platformWrite(const char * text, std::size_t length) noexcept;
-
-/*!
-  \brief Ends the run with the given code.
-
-  \param code  \c 0 when every assertion passed, \c 1 on any failure or a nested subcase, \c 2 on a duplicate
-               case name.
-
-  \note On consoles there is no process to exit, so the sink stores the code where a debugger reads it and then parks
-        the CPU.
-*/
-[[noreturn]] void platformExit(int code) noexcept;
-
 namespace detail {
 
 /*!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled test builds for Sega MegaDrive debug and release configurations.
  * Added platform-specific test runners for MegaDrive, GBA, Nintendo DS, 3DS, Switch, GameCube, Wii, and Wii U.
  * Added console-specific test output and executable or image generation.
  * Added MSVC runtime checks to debug builds.

* **Bug Fixes**
  * Improved test execution and reporting across supported platforms.
  * Test output now respects each platform’s console width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->